### PR TITLE
[#7, #16, #27] 웨이팅 호출 시 알림 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,9 @@ dependencies {
     compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/wait4eat/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/example/wait4eat/domain/notification/controller/NotificationController.java
@@ -4,6 +4,7 @@ import com.example.wait4eat.domain.notification.dto.response.NotificationRespons
 import com.example.wait4eat.domain.notification.service.NotificationService;
 import com.example.wait4eat.domain.notification.sse.SseEmitterManager;
 import com.example.wait4eat.global.auth.dto.AuthUser;
+import com.example.wait4eat.global.dto.response.PageResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -33,11 +34,13 @@ public class NotificationController {
     }
 
     @GetMapping("/api/v1/notifications")
-    public ResponseEntity<List<NotificationResponse>> getNotifications(
+    public ResponseEntity<PageResponse<NotificationResponse>> getNotifications(
             @AuthenticationPrincipal AuthUser authUser,
             @PageableDefault(page = 0, size = 10, sort = "createdAt", direction = Sort.Direction.DESC)
             Pageable pageable
     ) {
-        return ResponseEntity.ok(notificationService.getNotifications(authUser.getUserId(), pageable));
+        return ResponseEntity.ok(
+                PageResponse.from(notificationService.getNotifications(authUser.getUserId(), pageable))
+        );
     }
 }

--- a/src/main/java/com/example/wait4eat/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/example/wait4eat/domain/notification/controller/NotificationController.java
@@ -25,6 +25,12 @@ public class NotificationController {
     private final NotificationService notificationService;
     private final SseEmitterManager sseEmitterManager;
 
+    @GetMapping(value = "/api/v1/notifications/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter subscribe(
+            @RequestParam Long userId
+    ) {
+        return sseEmitterManager.connect(userId);
+    }
 
     @GetMapping("/api/v1/notifications")
     public ResponseEntity<List<NotificationResponse>> getNotifications(
@@ -34,6 +40,4 @@ public class NotificationController {
     ) {
         return ResponseEntity.ok(notificationService.getNotifications(authUser.getUserId(), pageable));
     }
-
-
 }

--- a/src/main/java/com/example/wait4eat/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/example/wait4eat/domain/notification/controller/NotificationController.java
@@ -1,0 +1,39 @@
+package com.example.wait4eat.domain.notification.controller;
+
+import com.example.wait4eat.domain.notification.dto.response.NotificationResponse;
+import com.example.wait4eat.domain.notification.service.NotificationService;
+import com.example.wait4eat.domain.notification.sse.SseEmitterManager;
+import com.example.wait4eat.global.auth.dto.AuthUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final NotificationService notificationService;
+    private final SseEmitterManager sseEmitterManager;
+
+
+    @GetMapping("/api/v1/notifications")
+    public ResponseEntity<List<NotificationResponse>> getNotifications(
+            @AuthenticationPrincipal AuthUser authUser,
+            @PageableDefault(page = 0, size = 10, sort = "createdAt", direction = Sort.Direction.DESC)
+            Pageable pageable
+    ) {
+        return ResponseEntity.ok(notificationService.getNotifications(authUser.getUserId(), pageable));
+    }
+
+
+}

--- a/src/main/java/com/example/wait4eat/domain/notification/dto/response/NotificationResponse.java
+++ b/src/main/java/com/example/wait4eat/domain/notification/dto/response/NotificationResponse.java
@@ -11,11 +11,11 @@ import java.time.LocalDateTime;
 @Getter
 public class NotificationResponse {
 
-    private Long id;
-    private NotificationType type;
-    private Boolean isRead;
-    private String text;
-    private LocalDateTime createdAt;
+    private final Long id;
+    private final NotificationType type;
+    private final Boolean isRead;
+    private final String text;
+    private final LocalDateTime createdAt;
 
     @Builder
     private NotificationResponse(Long id, NotificationType type, Boolean isRead, String text, LocalDateTime createdAt) {

--- a/src/main/java/com/example/wait4eat/domain/notification/dto/response/NotificationResponse.java
+++ b/src/main/java/com/example/wait4eat/domain/notification/dto/response/NotificationResponse.java
@@ -1,0 +1,38 @@
+package com.example.wait4eat.domain.notification.dto.response;
+
+import com.example.wait4eat.domain.notification.entity.Notification;
+import com.example.wait4eat.domain.notification.enums.NotificationType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class NotificationResponse {
+
+    private Long id;
+    private NotificationType type;
+    private Boolean isRead;
+    private String text;
+    private LocalDateTime createdAt;
+
+    @Builder
+    private NotificationResponse(Long id, NotificationType type, Boolean isRead, String text, LocalDateTime createdAt) {
+        this.id = id;
+        this.type = type;
+        this.isRead = isRead;
+        this.text = text;
+        this.createdAt = createdAt;
+    }
+
+    public static NotificationResponse from(Notification notification) {
+        return NotificationResponse.builder()
+                .id(notification.getId())
+                .type(notification.getType())
+                .isRead(notification.getIsRead())
+                .text(notification.getText())
+                .createdAt(notification.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/example/wait4eat/domain/notification/entity/Notification.java
+++ b/src/main/java/com/example/wait4eat/domain/notification/entity/Notification.java
@@ -28,6 +28,7 @@ public class Notification {
     private User user;
 
     @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private NotificationType type;
 
     private String text;

--- a/src/main/java/com/example/wait4eat/domain/notification/enums/NotificationType.java
+++ b/src/main/java/com/example/wait4eat/domain/notification/enums/NotificationType.java
@@ -1,5 +1,16 @@
 package com.example.wait4eat.domain.notification.enums;
 
 public enum NotificationType {
-    SMS, PUSH
+
+    WAITING_CALLED("웨이팅이 호출되었습니다. 가게로 입장해주세요.");
+
+    private final String message;
+
+    NotificationType(String message) {
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
 }

--- a/src/main/java/com/example/wait4eat/domain/notification/event/NotificationEvent.java
+++ b/src/main/java/com/example/wait4eat/domain/notification/event/NotificationEvent.java
@@ -1,0 +1,30 @@
+package com.example.wait4eat.domain.notification.event;
+
+import com.example.wait4eat.domain.notification.entity.Notification;
+import com.example.wait4eat.domain.notification.enums.NotificationType;
+import lombok.Builder;
+
+import lombok.Getter;
+
+@Getter
+public class NotificationEvent {
+
+    private final Long userId;
+    private final NotificationType type;
+    private final String message;
+
+    @Builder
+    private NotificationEvent(Long userId, NotificationType type, String message) {
+        this.userId = userId;
+        this.type = type;
+        this.message = message;
+    }
+
+    public static NotificationEvent from(Notification notification) {
+        return NotificationEvent.builder()
+                .userId(notification.getUser().getId())
+                .type(notification.getType())
+                .message(notification.getText())
+                .build();
+    }
+}

--- a/src/main/java/com/example/wait4eat/domain/notification/handler/NotificationEventHandler.java
+++ b/src/main/java/com/example/wait4eat/domain/notification/handler/NotificationEventHandler.java
@@ -1,0 +1,23 @@
+package com.example.wait4eat.domain.notification.handler;
+
+import com.example.wait4eat.domain.notification.event.NotificationEvent;
+import com.example.wait4eat.domain.notification.publisher.NotificationPublisher;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationEventHandler {
+
+    private final NotificationPublisher notificationPublisher;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(NotificationEvent event) {
+        log.info("이제 여기서 실제 알림 전송 로직 호출");
+        notificationPublisher.publish(event);
+    }
+}

--- a/src/main/java/com/example/wait4eat/domain/notification/publisher/NotificationPublisher.java
+++ b/src/main/java/com/example/wait4eat/domain/notification/publisher/NotificationPublisher.java
@@ -1,0 +1,7 @@
+package com.example.wait4eat.domain.notification.publisher;
+
+import com.example.wait4eat.domain.notification.event.NotificationEvent;
+
+public interface NotificationPublisher {
+    void publish(NotificationEvent notificationEvent);
+}

--- a/src/main/java/com/example/wait4eat/domain/notification/publisher/RedisNotificationPublisher.java
+++ b/src/main/java/com/example/wait4eat/domain/notification/publisher/RedisNotificationPublisher.java
@@ -1,0 +1,30 @@
+package com.example.wait4eat.domain.notification.publisher;
+
+import com.example.wait4eat.domain.notification.event.NotificationEvent;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisNotificationPublisher implements NotificationPublisher {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final ObjectMapper objectMapper;
+    private final ChannelTopic channelTopic;
+
+    @Override
+    public void publish(NotificationEvent event) {
+        try {
+            String message = objectMapper.writeValueAsString(event);
+            redisTemplate.convertAndSend(channelTopic.getTopic(), message);
+        } catch (JsonProcessingException e) {
+            log.error("Redis publish 실패: {}", e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/example/wait4eat/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/example/wait4eat/domain/notification/repository/NotificationRepository.java
@@ -1,7 +1,12 @@
 package com.example.wait4eat.domain.notification.repository;
 
 import com.example.wait4eat.domain.notification.entity.Notification;
+import com.example.wait4eat.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    Page<Notification> findAllByUser(User user, Pageable pageable);
 }

--- a/src/main/java/com/example/wait4eat/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/example/wait4eat/domain/notification/service/NotificationService.java
@@ -1,0 +1,38 @@
+package com.example.wait4eat.domain.notification.service;
+
+import com.example.wait4eat.domain.notification.entity.Notification;
+import com.example.wait4eat.domain.notification.enums.NotificationType;
+import com.example.wait4eat.domain.notification.repository.NotificationRepository;
+import com.example.wait4eat.domain.user.entity.User;
+import com.example.wait4eat.domain.user.repository.UserRepository;
+import com.example.wait4eat.global.exception.CustomException;
+import com.example.wait4eat.global.exception.ExceptionType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public Notification create(Long userId, NotificationType notificationType) {
+        User user =  getUserById(userId);
+
+        return notificationRepository.save(
+                Notification.builder()
+                        .user(user)
+                        .type(notificationType)
+                        .text(notificationType.getMessage())
+                        .build()
+        );
+    }
+
+    private User getUserById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ExceptionType.USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/example/wait4eat/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/example/wait4eat/domain/notification/service/NotificationService.java
@@ -9,12 +9,11 @@ import com.example.wait4eat.domain.user.repository.UserRepository;
 import com.example.wait4eat.global.exception.CustomException;
 import com.example.wait4eat.global.exception.ExceptionType;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -37,13 +36,11 @@ public class NotificationService {
     }
 
     @Transactional(readOnly = true)
-    public List<NotificationResponse> getNotifications(Long userId, Pageable pageable) {
+    public Page<NotificationResponse> getNotifications(Long userId, Pageable pageable) {
         User user = getUserById(userId);
 
         return notificationRepository.findAllByUser(user, pageable)
-                .stream()
-                .map(NotificationResponse::from)
-                .toList();
+                .map(NotificationResponse::from);
     }
 
     private User getUserById(Long userId) {

--- a/src/main/java/com/example/wait4eat/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/example/wait4eat/domain/notification/service/NotificationService.java
@@ -1,5 +1,6 @@
 package com.example.wait4eat.domain.notification.service;
 
+import com.example.wait4eat.domain.notification.dto.response.NotificationResponse;
 import com.example.wait4eat.domain.notification.entity.Notification;
 import com.example.wait4eat.domain.notification.enums.NotificationType;
 import com.example.wait4eat.domain.notification.repository.NotificationRepository;
@@ -8,8 +9,12 @@ import com.example.wait4eat.domain.user.repository.UserRepository;
 import com.example.wait4eat.global.exception.CustomException;
 import com.example.wait4eat.global.exception.ExceptionType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -31,8 +36,20 @@ public class NotificationService {
         );
     }
 
+    @Transactional(readOnly = true)
+    public List<NotificationResponse> getNotifications(Long userId, Pageable pageable) {
+        User user = getUserById(userId);
+
+        return notificationRepository.findAllByUser(user, pageable)
+                .stream()
+                .map(NotificationResponse::from)
+                .toList();
+    }
+
     private User getUserById(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ExceptionType.USER_NOT_FOUND));
     }
+
+
 }

--- a/src/main/java/com/example/wait4eat/domain/notification/sse/SseEmitterManager.java
+++ b/src/main/java/com/example/wait4eat/domain/notification/sse/SseEmitterManager.java
@@ -1,0 +1,45 @@
+package com.example.wait4eat.domain.notification.sse;
+
+import com.example.wait4eat.domain.notification.event.NotificationEvent;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@Component
+public class SseEmitterManager {
+
+    private final static Long SSE_TIMEOUT_MS = 60 * 1000L * 5; // 5분
+
+    private final Map<Long, SseEmitter> emitterMap = new ConcurrentHashMap<>();
+
+
+    public SseEmitter connect(Long userId) {
+        SseEmitter emitter = new SseEmitter(SSE_TIMEOUT_MS);
+        emitterMap.put(userId, emitter);
+
+        emitter.onCompletion(() -> emitterMap.remove(userId));
+        emitter.onTimeout(() -> emitterMap.remove(userId));
+        emitter.onError(e -> emitterMap.remove(userId));
+
+        return emitter;
+    }
+
+    public void send(Long userId, NotificationEvent event) {
+        SseEmitter emitter = emitterMap.get(userId);
+        if (emitter != null) {
+            try {
+                emitter.send(SseEmitter.event()
+                        .name("notification")
+                        .data(event));
+            } catch (IOException e) {
+                log.error("SSE 전송 실패: userId={}", userId, e);
+                emitterMap.remove(userId);
+            }
+        }
+    }
+}

--- a/src/main/java/com/example/wait4eat/domain/notification/subscriber/RedisSubscriber.java
+++ b/src/main/java/com/example/wait4eat/domain/notification/subscriber/RedisSubscriber.java
@@ -1,0 +1,35 @@
+package com.example.wait4eat.domain.notification.subscriber;
+
+import com.example.wait4eat.domain.notification.event.NotificationEvent;
+import com.example.wait4eat.domain.notification.sse.SseEmitterManager;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisSubscriber implements MessageListener {
+
+    private final ObjectMapper objectMapper;
+    private final SseEmitterManager sseEmitterManager;
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        try {
+            String json = new String(message.getBody());
+            NotificationEvent event = objectMapper.readValue(json, NotificationEvent.class);
+            log.debug("Redis 메시지 수신: userId={}, type={}", event.getUserId(), event.getType());
+
+            sseEmitterManager.send(event.getUserId(), event);
+        } catch (JsonProcessingException e) {
+            log.error("Redis 메시지 파싱 실패", e);
+        } catch (Exception e) {
+            log.error("SSE 알림 전송 실패", e);
+        }
+    }
+}

--- a/src/main/java/com/example/wait4eat/domain/waiting/event/WaitingCalledEvent.java
+++ b/src/main/java/com/example/wait4eat/domain/waiting/event/WaitingCalledEvent.java
@@ -1,0 +1,25 @@
+package com.example.wait4eat.domain.waiting.event;
+
+import com.example.wait4eat.domain.waiting.entity.Waiting;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class WaitingCalledEvent {
+
+    private final Long waitingId;
+    private final Long userId;
+
+    @Builder
+    private WaitingCalledEvent(Long waitingId, Long userId) {
+        this.waitingId = waitingId;
+        this.userId = userId;
+    }
+
+    public static WaitingCalledEvent from(Waiting waiting) {
+        return WaitingCalledEvent.builder()
+                .waitingId(waiting.getId())
+                .userId(waiting.getUser().getId())
+                .build();
+    }
+}

--- a/src/main/java/com/example/wait4eat/domain/waiting/handler/WaitingCalledEventHandler.java
+++ b/src/main/java/com/example/wait4eat/domain/waiting/handler/WaitingCalledEventHandler.java
@@ -1,0 +1,31 @@
+package com.example.wait4eat.domain.waiting.handler;
+
+import com.example.wait4eat.domain.notification.entity.Notification;
+import com.example.wait4eat.domain.notification.enums.NotificationType;
+import com.example.wait4eat.domain.notification.event.NotificationEvent;
+import com.example.wait4eat.domain.notification.service.NotificationService;
+import com.example.wait4eat.domain.waiting.event.WaitingCalledEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class WaitingCalledEventHandler {
+
+    private final NotificationService notificationService;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void handle(WaitingCalledEvent event) {
+        Notification notification = notificationService.create(
+                event.getUserId(),
+                NotificationType.WAITING_CALLED
+        );
+        eventPublisher.publishEvent(
+                new NotificationEvent(event.getUserId(), notification.getType())
+        );
+    }
+}

--- a/src/main/java/com/example/wait4eat/domain/waiting/handler/WaitingCalledEventHandler.java
+++ b/src/main/java/com/example/wait4eat/domain/waiting/handler/WaitingCalledEventHandler.java
@@ -24,8 +24,6 @@ public class WaitingCalledEventHandler {
                 event.getUserId(),
                 NotificationType.WAITING_CALLED
         );
-        eventPublisher.publishEvent(
-                new NotificationEvent(event.getUserId(), notification.getType())
-        );
+        eventPublisher.publishEvent(NotificationEvent.from(notification));
     }
 }

--- a/src/main/java/com/example/wait4eat/global/auth/security/SecurityConfig.java
+++ b/src/main/java/com/example/wait4eat/global/auth/security/SecurityConfig.java
@@ -44,6 +44,8 @@ public class SecurityConfig {
                 .logout(AbstractHttpConfigurer::disable)
                 .rememberMe(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/test-sse.html", "/css/**", "/js/**", "/images/**").permitAll()
+                        .requestMatchers(request -> request.getRequestURI().startsWith("/api/v1/notifications/subscribe")).permitAll()
                         .requestMatchers(request -> request.getRequestURI().startsWith("/api/v1/auth")).permitAll()
                         // ROLE_OWNER만 허용
                         .requestMatchers(HttpMethod.POST, "/api/v1/stores").hasAuthority(UserRole.Authority.OWNER)

--- a/src/main/java/com/example/wait4eat/global/config/RedisConfig.java
+++ b/src/main/java/com/example/wait4eat/global/config/RedisConfig.java
@@ -1,0 +1,40 @@
+package com.example.wait4eat.global.config;
+
+import com.example.wait4eat.domain.notification.subscriber.RedisSubscriber;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.PatternTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+
+@Configuration
+@RequiredArgsConstructor
+public class RedisConfig {
+
+    private final RedisSubscriber redisSubscriber;
+    private final ObjectMapper objectMapper;
+
+    @Value("${redis.notification-topic}")
+    private String notificationTopic;
+
+    @Bean
+    public RedisMessageListenerContainer redisMessageListenerContainer(
+            RedisConnectionFactory connectionFactory
+    ) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+
+        // 구독 채널 등록
+        container.addMessageListener(redisSubscriber, new PatternTopic(notificationTopic));
+        return container;
+    }
+
+    @Bean
+    public ChannelTopic notificationChannelTopic() {
+        return new ChannelTopic(notificationTopic);
+    }
+}


### PR DESCRIPTION
## 상세 설명
- `웨이팅 호출` 이벤트 발행 시 `알림`이 생성되어 저장됩니다.
- 저장된 알림은 `알림 전송` 이벤트 발행 시 SSE 구독으로 연결된 사용자에게 전송됩니다.
- SSE 구독 API는 현재 파라미터로 userId를 전달하고 있으며, 이는 추후 개선이 필요합니다.

this closes #7 , #16 , #27 