### PR TITLE
[#69] 알림 SSE 연결 시 보안 강화 구현

### DIFF
--- a/src/main/java/com/example/wait4eat/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/wait4eat/domain/auth/service/AuthService.java
@@ -52,7 +52,7 @@ public class AuthService {
             throw new CustomException(ExceptionType.INCORRECT_PASSWORD);
         }
 
-        String bearerToken = jwtUtil.createToken(user.getId(), user.getEmail(), user.getRole());
+        String bearerToken = jwtUtil.createAccessToken(user.getId(), user.getEmail(), user.getRole());
 
         return SigninResponse.of(user, bearerToken);
     }

--- a/src/main/java/com/example/wait4eat/global/exception/ExceptionType.java
+++ b/src/main/java/com/example/wait4eat/global/exception/ExceptionType.java
@@ -17,6 +17,7 @@ public enum ExceptionType {
 
     // Jwt
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+    INVALID_SCOPE(HttpStatus.UNAUTHORIZED, "유효하지 않은 scope의 토큰입니다."),
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
     UNSUPPORTED_TOKEN(HttpStatus.BAD_REQUEST, "지원되지 않는 JWT 토큰입니다."),
     TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "토큰이 존재하지 않습니다."),

--- a/src/main/resources/static/test-sse.html
+++ b/src/main/resources/static/test-sse.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>SSE Notification</title>
+    <style>
+        body {
+            font-family: 'Arial', sans-serif;
+            background-color: #f6f8fa;
+            margin: 0;
+            padding: 20px;
+        }
+
+        .container {
+            max-width: 500px;
+            margin: 0 auto;
+        }
+
+        h1 {
+            text-align: center;
+            color: #2c3e50;
+        }
+
+        .notification-box {
+            background-color: white;
+            border: 1px solid #e1e4e8;
+            border-radius: 8px;
+            padding: 15px;
+            margin-bottom: 10px;
+            box-shadow: 0 2px 5px rgba(0,0,0,0.05);
+            transition: background-color 0.3s ease;
+        }
+
+        .notification-box:hover {
+            background-color: #f1f1f1;
+        }
+
+        .notification-box time {
+            display: block;
+            font-size: 12px;
+            color: #6c757d;
+            margin-top: 5px;
+        }
+
+        #log {
+            margin-top: 30px;
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+    <h1>📡 실시간 알림</h1>
+    <div id="log"></div>
+</div>
+
+<script>
+    const token = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwic2NvcGUiOiJzc2UiLCJleHAiOjE3NDQ4NTc1MDksImlhdCI6MTc0NDg1NzM4OX0.ReJL3UfHgLx1kjg_1LiuAa_ZSKy0bW9OEx-0HpFVZX8";
+    const eventSource = new EventSource(`/api/v1/notifications/subscribe?token=${token}`);
+
+    eventSource.onopen = () => {
+        console.log("✅ SSE 연결 성공");
+    };
+
+    eventSource.addEventListener("notification", (event) => {
+        const data = JSON.parse(event.data);
+        const log = document.getElementById("log");
+
+        const div = document.createElement("div");
+        div.className = "notification-box";
+        div.innerHTML = `
+        <strong>🔔 ${data.type}</strong>
+        <div>${data.message}</div>
+        <time>${new Date().toLocaleString()}</time>
+      `;
+
+        // 새 알림이 위에 오도록 prepend
+        log.prepend(div);
+    });
+
+    eventSource.onerror = (error) => {
+        console.error("❌ SSE 오류 발생", error);
+    };
+</script>
+</body>
+</html>


### PR DESCRIPTION
## 🧩 연관된 이슈

#69 

## ✅ 작업 내용

1. JwtUtil 확장 및 변경
- sseToken 발급 메서드 추가
- sseToken 발급 메서드를 추가하면서 기존 accessToken을 생성하던 createToken 메서드의 네이밍을 createAccessToken으로 변경했습니다.
- scope을 확인하는 메서드를 추가했습니다.

2. SSE 전용 Token 발급 및 검증 로직 추가
- SSE token 발급 API 추가
- SSE 연결 시 userId 대신 token을 받아오도록 변경, 검증 후 connect 처리

## 📷 테스트

- 포스트맨과 test-sse.html을 통해 token을 발급받고, 해당 token을 이용해서 정상적으로 알림이 수신됨을 확인하였습니다.

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
