### PR TITLE
알림 시스템에 SQS 적용 및 재시도 로직 구현

### DIFF
--- a/src/main/java/com/example/wait4eat/Wait4eatApplication.java
+++ b/src/main/java/com/example/wait4eat/Wait4eatApplication.java
@@ -4,7 +4,9 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @EnableAsync
 @EnableJpaAuditing
 @SpringBootApplication

--- a/src/main/java/com/example/wait4eat/client/SlackNotificationService.java
+++ b/src/main/java/com/example/wait4eat/client/SlackNotificationService.java
@@ -1,0 +1,24 @@
+package com.example.wait4eat.client;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SlackNotificationService {
+
+    @Value("${slack.web-hook-url}")
+    private String slackWebhookUrl;
+    private RestTemplate restTemplate = new RestTemplate();
+
+    // TODO : 조금 더 구조화 필요
+    public void sendNotificationToSlack(String message) {
+        String payload = "{\"text\" : \"" + message + "\"}";
+        restTemplate.postForObject(slackWebhookUrl, payload, String.class);
+        log.info("Slack notification sent to slack webhook: {}", payload);
+    }
+}

--- a/src/main/java/com/example/wait4eat/domain/coupon_event/event/handler/CouponEventLaunchedEventHandler.java
+++ b/src/main/java/com/example/wait4eat/domain/coupon_event/event/handler/CouponEventLaunchedEventHandler.java
@@ -1,0 +1,45 @@
+package com.example.wait4eat.domain.coupon_event.event.handler;
+
+import com.example.wait4eat.domain.coupon_event.event.CouponEventLaunchedEvent;
+import com.example.wait4eat.global.message.dto.NotificationMessagePublishRequest;
+import com.example.wait4eat.global.message.enums.MessageType;
+import com.example.wait4eat.global.message.outbox.entity.OutboxMessage;
+import com.example.wait4eat.global.message.outbox.event.OutboxSavedEvent;
+import com.example.wait4eat.global.message.service.MessageStagingService;
+import com.example.wait4eat.domain.notification.enums.NotificationType;
+import com.example.wait4eat.domain.storewishlist.repository.StoreWishlistRepository;
+import com.example.wait4eat.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CouponEventLaunchedEventHandler {
+
+    private final StoreWishlistRepository storeWishlistRepository;
+    private final MessageStagingService messageStagingService;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void handle(CouponEventLaunchedEvent event) {
+        List<User> users = storeWishlistRepository.findAllUsersByStoreId(event.getStoreId());
+
+        String message = "[" + event.getStoreName() + "] " + NotificationType.COUPON_EVENT_LAUNCHED.getMessage();
+        NotificationMessagePublishRequest notificationMessagePublishRequest = new NotificationMessagePublishRequest(
+                MessageType.COUPON_EVENT_LAUNCHED,
+                message,
+                users,
+                NotificationType.COUPON_EVENT_LAUNCHED
+        );
+
+        List<OutboxMessage> outboxes = messageStagingService.stage(notificationMessagePublishRequest);
+        eventPublisher.publishEvent(new OutboxSavedEvent(outboxes));
+    }
+}

--- a/src/main/java/com/example/wait4eat/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/example/wait4eat/domain/notification/controller/NotificationController.java
@@ -2,7 +2,7 @@ package com.example.wait4eat.domain.notification.controller;
 
 import com.example.wait4eat.domain.notification.dto.response.NotificationResponse;
 import com.example.wait4eat.domain.notification.service.NotificationService;
-import com.example.wait4eat.domain.notification.sse.SseEmitterManager;
+import com.example.wait4eat.infra.sse.SseEmitterManager;
 import com.example.wait4eat.global.auth.dto.AuthUser;
 import com.example.wait4eat.global.auth.jwt.JwtUtil;
 import com.example.wait4eat.global.dto.response.PageResponse;

--- a/src/main/java/com/example/wait4eat/domain/notification/entity/Notification.java
+++ b/src/main/java/com/example/wait4eat/domain/notification/entity/Notification.java
@@ -2,6 +2,7 @@ package com.example.wait4eat.domain.notification.entity;
 
 import com.example.wait4eat.domain.notification.enums.NotificationType;
 import com.example.wait4eat.domain.user.entity.User;
+import com.example.wait4eat.global.util.IdGenerator;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -20,7 +21,6 @@ import java.time.LocalDateTime;
 public class Notification {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -41,6 +41,7 @@ public class Notification {
 
     @Builder
     public Notification(User user, NotificationType type, String text) {
+        this.id = IdGenerator.generateNotificationId();
         this.user = user;
         this.type = type;
         this.text = text;

--- a/src/main/java/com/example/wait4eat/domain/notification/publisher/NotificationPublisher.java
+++ b/src/main/java/com/example/wait4eat/domain/notification/publisher/NotificationPublisher.java
@@ -1,7 +1,7 @@
 package com.example.wait4eat.domain.notification.publisher;
 
-import com.example.wait4eat.domain.notification.event.NotificationEvent;
+import com.example.wait4eat.global.message.payload.NotificationPayload;
 
 public interface NotificationPublisher {
-    void publish(NotificationEvent notificationEvent);
+    void publish(NotificationPayload notificationPayload);
 }

--- a/src/main/java/com/example/wait4eat/domain/notification/repository/NotificationJdbcRepository.java
+++ b/src/main/java/com/example/wait4eat/domain/notification/repository/NotificationJdbcRepository.java
@@ -1,0 +1,33 @@
+package com.example.wait4eat.domain.notification.repository;
+
+import com.example.wait4eat.domain.notification.entity.Notification;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class NotificationJdbcRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    private final String INSERT_SQL = """
+            INSERT INTO notifications
+            (id, user_id, text, type, is_read, created_at)
+            VALUES (?, ?, ?, ?, ?, now())
+            """;
+
+    public void saveAll(List<Notification> notifications) {
+        jdbcTemplate.batchUpdate(INSERT_SQL, notifications, 1000,
+                ((ps, notification) -> {
+                    ps.setLong(1, notification.getId());
+                    ps.setLong(2, notification.getUser().getId());
+                    ps.setString(3, notification.getText());
+                    ps.setString(4, notification.getType().name());
+                    ps.setBoolean(5, notification.getIsRead());
+                }
+        ));
+    }
+}

--- a/src/main/java/com/example/wait4eat/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/example/wait4eat/domain/notification/service/NotificationService.java
@@ -1,18 +1,23 @@
 package com.example.wait4eat.domain.notification.service;
 
+import com.example.wait4eat.global.message.payload.NotificationPayload;
 import com.example.wait4eat.domain.notification.dto.response.NotificationResponse;
 import com.example.wait4eat.domain.notification.entity.Notification;
 import com.example.wait4eat.domain.notification.enums.NotificationType;
+import com.example.wait4eat.domain.notification.repository.NotificationJdbcRepository;
 import com.example.wait4eat.domain.notification.repository.NotificationRepository;
 import com.example.wait4eat.domain.user.entity.User;
 import com.example.wait4eat.domain.user.repository.UserRepository;
 import com.example.wait4eat.global.exception.CustomException;
 import com.example.wait4eat.global.exception.ExceptionType;
+import com.example.wait4eat.global.util.IdGenerator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 
 @Service
@@ -20,6 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class NotificationService {
 
     private final NotificationRepository notificationRepository;
+    private final NotificationJdbcRepository  notificationJdbcRepository;
     private final UserRepository userRepository;
 
     @Transactional
@@ -33,6 +39,20 @@ public class NotificationService {
                         .text(message)
                         .build()
         );
+    }
+
+    @Transactional
+    public List<Notification> createBulk(List<User> users, NotificationType type, String message) {
+        List<Notification> notifications = users.stream()
+                .map(user -> Notification.builder()
+                        .user(user)
+                        .type(type)
+                        .text(message)
+                        .build())
+                .toList();
+
+        notificationJdbcRepository.saveAll(notifications);
+        return notifications;
     }
 
     @Transactional(readOnly = true)
@@ -65,5 +85,4 @@ public class NotificationService {
         return notificationRepository.findById(notificationId)
                 .orElseThrow(() -> new CustomException(ExceptionType.NOTIFICATION_NOT_FOUND));
     }
-
 }

--- a/src/main/java/com/example/wait4eat/domain/waiting/event/handler/WaitingCalledEventHandler.java
+++ b/src/main/java/com/example/wait4eat/domain/waiting/event/handler/WaitingCalledEventHandler.java
@@ -1,0 +1,46 @@
+package com.example.wait4eat.domain.waiting.event.handler;
+
+import com.example.wait4eat.domain.user.entity.User;
+import com.example.wait4eat.domain.user.repository.UserRepository;
+import com.example.wait4eat.global.exception.CustomException;
+import com.example.wait4eat.global.exception.ExceptionType;
+import com.example.wait4eat.global.message.dto.NotificationMessagePublishRequest;
+import com.example.wait4eat.global.message.enums.MessageType;
+import com.example.wait4eat.domain.notification.enums.NotificationType;
+import com.example.wait4eat.domain.waiting.event.WaitingCalledEvent;
+import com.example.wait4eat.global.message.outbox.entity.OutboxMessage;
+import com.example.wait4eat.global.message.outbox.event.OutboxSavedEvent;
+import com.example.wait4eat.global.message.service.MessageStagingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class WaitingCalledEventHandler {
+
+    private final UserRepository userRepository;
+    private final MessageStagingService messageStagingService;
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void handle(WaitingCalledEvent event) {
+        User user = userRepository.findById(event.getUserId())
+                    .orElseThrow(() -> new CustomException(ExceptionType.USER_NOT_FOUND));
+
+        NotificationMessagePublishRequest notificationMessagePublishRequest = new NotificationMessagePublishRequest(
+                MessageType.WAITING_CALLED,
+                NotificationType.COUPON_EVENT_LAUNCHED.getMessage(),
+                List.of(user),
+                NotificationType.COUPON_EVENT_LAUNCHED
+        );
+
+        List<OutboxMessage> outboxes = messageStagingService.stage(notificationMessagePublishRequest);
+
+        applicationEventPublisher.publishEvent(new OutboxSavedEvent(outboxes));
+    }
+}

--- a/src/main/java/com/example/wait4eat/global/config/RedisConfig.java
+++ b/src/main/java/com/example/wait4eat/global/config/RedisConfig.java
@@ -1,6 +1,6 @@
 package com.example.wait4eat.global.config;
 
-import com.example.wait4eat.domain.notification.subscriber.RedisSubscriber;
+import com.example.wait4eat.infra.redis.subscriber.RedisSubscriber;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/com/example/wait4eat/global/message/dedup/CompositeMessageDeduplicationHandler.java
+++ b/src/main/java/com/example/wait4eat/global/message/dedup/CompositeMessageDeduplicationHandler.java
@@ -1,0 +1,38 @@
+package com.example.wait4eat.global.message.dedup;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Primary
+@Component
+@RequiredArgsConstructor
+public class CompositeMessageDeduplicationHandler implements MessageDeduplicationHandler {
+
+    private final RedisMessageDeduplicationHandler redisHandler;
+    private final DbMessageDeduplicationHandler dbHandler;
+
+    @Transactional(readOnly = true)
+    public boolean isDuplicated(String messageKey) {
+        if (redisHandler.isDuplicated(messageKey)) {
+            return true;
+        }
+        return dbHandler.isDuplicated(messageKey);
+    }
+
+    @Transactional
+    public void markAsProcessed(String messageKey) {
+        try {
+            dbHandler.markAsProcessed(messageKey);
+            redisHandler.markAsProcessed(messageKey);
+        } catch (Exception e) {
+            log.error("Inbox 마킹 실패: {}", messageKey, e);
+            throw new RuntimeException(e); // 재시도 유도
+        }
+
+        log.info("messageKey 처리 마킹 완료: {}", messageKey);
+    }
+}

--- a/src/main/java/com/example/wait4eat/global/message/dedup/DbMessageDeduplicationHandler.java
+++ b/src/main/java/com/example/wait4eat/global/message/dedup/DbMessageDeduplicationHandler.java
@@ -1,0 +1,35 @@
+package com.example.wait4eat.global.message.dedup;
+
+import com.example.wait4eat.global.message.inbox.entity.InboxMessage;
+import com.example.wait4eat.global.message.inbox.repository.InboxRepository;
+import com.example.wait4eat.global.message.outbox.repository.OutboxMessageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class DbMessageDeduplicationHandler implements MessageDeduplicationHandler {
+
+    private final OutboxMessageRepository outboxRepository;
+    private final InboxRepository inboxRepository;
+
+    @Override
+    public boolean isDuplicated(String messageKey) {
+        if (inboxRepository.findById(messageKey).orElse(null) == null) {
+            return false;
+        }
+        return true;
+//        return outboxRepository.existsByIdAndIsProcessed(messageKey, true);
+    }
+
+
+    @Transactional
+    @Override
+    public void markAsProcessed(String messageKey) {
+        inboxRepository.save(new InboxMessage(messageKey));
+//        OutboxMessage outboxMessage = outboxRepository.findById(messageKey)
+//                .orElseThrow(() -> new IllegalArgumentException("outboxId: " + messageKey + " not found"));
+//        outboxMessage.markAsProcessed();
+    }
+}

--- a/src/main/java/com/example/wait4eat/global/message/dedup/MessageDeduplicationHandler.java
+++ b/src/main/java/com/example/wait4eat/global/message/dedup/MessageDeduplicationHandler.java
@@ -1,0 +1,6 @@
+package com.example.wait4eat.global.message.dedup;
+
+public interface MessageDeduplicationHandler {
+    boolean isDuplicated(String messageKey);
+    void markAsProcessed(String messageKey);
+}

--- a/src/main/java/com/example/wait4eat/global/message/dedup/RedisMessageDeduplicationHandler.java
+++ b/src/main/java/com/example/wait4eat/global/message/dedup/RedisMessageDeduplicationHandler.java
@@ -1,0 +1,32 @@
+package com.example.wait4eat.global.message.dedup;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Component
+@RequiredArgsConstructor
+public class RedisMessageDeduplicationHandler implements MessageDeduplicationHandler {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private static final Duration TTL = Duration.ofHours(1);
+    private static final String DEDUP_MESSAGE_PREFIX = "dedup:message:";
+
+    @Override
+    public boolean isDuplicated(String messageKey) {
+        String key = getKey(messageKey);
+        return Boolean.TRUE.equals(redisTemplate.hasKey(key));
+    }
+
+    @Override
+    public void markAsProcessed(String messageKey) {
+        String key = getKey(messageKey);
+        redisTemplate.opsForValue().set(key, "1", TTL);
+    }
+
+    private String getKey(String messageKey) {
+        return DEDUP_MESSAGE_PREFIX + messageKey;
+    }
+}

--- a/src/main/java/com/example/wait4eat/global/message/dto/MessagePublishRequest.java
+++ b/src/main/java/com/example/wait4eat/global/message/dto/MessagePublishRequest.java
@@ -1,0 +1,19 @@
+package com.example.wait4eat.global.message.dto;
+
+import com.example.wait4eat.global.message.enums.MessageType;
+import com.example.wait4eat.global.message.payload.MessagePayload;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public abstract class MessagePublishRequest {
+
+    private final MessageType type;
+    private final String message;
+
+    public MessagePublishRequest(MessageType type, String message) {
+        this.type = type;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/example/wait4eat/global/message/dto/NotificationMessagePublishRequest.java
+++ b/src/main/java/com/example/wait4eat/global/message/dto/NotificationMessagePublishRequest.java
@@ -1,0 +1,26 @@
+package com.example.wait4eat.global.message.dto;
+
+import com.example.wait4eat.domain.notification.enums.NotificationType;
+import com.example.wait4eat.domain.user.entity.User;
+import com.example.wait4eat.global.message.enums.MessageType;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class NotificationMessagePublishRequest extends MessagePublishRequest {
+
+    private List<User> targetUsers;
+    private NotificationType notificationType;
+
+    public NotificationMessagePublishRequest(
+            MessageType type,
+            String message,
+            List<User> targetUsers,
+            NotificationType notificationType
+    ) {
+        super(type, message);
+        this.targetUsers = targetUsers;
+        this.notificationType = notificationType;
+    }
+}

--- a/src/main/java/com/example/wait4eat/global/message/enums/MessageType.java
+++ b/src/main/java/com/example/wait4eat/global/message/enums/MessageType.java
@@ -1,0 +1,16 @@
+package com.example.wait4eat.global.message.enums;
+
+public enum MessageType {
+    WAITING_CALLED(true),
+    COUPON_EVENT_LAUNCHED(true);
+
+    private final boolean requiresNotification;
+
+    MessageType(boolean requiresNotification) {
+        this.requiresNotification = requiresNotification;
+    }
+
+    public boolean requiresNotification() {
+        return this.requiresNotification;
+    }
+}

--- a/src/main/java/com/example/wait4eat/global/message/inbox/entity/InboxMessage.java
+++ b/src/main/java/com/example/wait4eat/global/message/inbox/entity/InboxMessage.java
@@ -1,0 +1,30 @@
+package com.example.wait4eat.global.message.inbox.entity;
+
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "inbox_messages")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class InboxMessage {
+
+    @Id
+    @Column(length = 36, unique = true)
+    private String id; // SQS 메시지 ID
+
+    @CreatedDate
+    private LocalDateTime receivedAt;
+
+    public InboxMessage(String id) {
+        this.id = id;
+    }
+}

--- a/src/main/java/com/example/wait4eat/global/message/inbox/repository/InboxRepository.java
+++ b/src/main/java/com/example/wait4eat/global/message/inbox/repository/InboxRepository.java
@@ -1,0 +1,7 @@
+package com.example.wait4eat.global.message.inbox.repository;
+
+import com.example.wait4eat.global.message.inbox.entity.InboxMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InboxRepository extends JpaRepository<InboxMessage, String> {
+}

--- a/src/main/java/com/example/wait4eat/global/message/outbox/entity/OutboxMessage.java
+++ b/src/main/java/com/example/wait4eat/global/message/outbox/entity/OutboxMessage.java
@@ -1,0 +1,73 @@
+package com.example.wait4eat.global.message.outbox.entity;
+
+import com.example.wait4eat.global.message.outbox.enums.OutboxMessageStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "outbox_messages",
+        indexes = {
+                @Index(name = "idx_status_created_at", columnList = "status, createdAt")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class OutboxMessage {
+
+    @Id
+    @Column(length = 36, unique = true)
+    private String id;
+
+    @Column(nullable = false)
+    private String aggregateType;
+
+    @Column
+    private Long aggregateId;
+
+    @Column(nullable = false)
+    private String payload;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private OutboxMessageStatus status = OutboxMessageStatus.PENDING;
+
+    @Column(nullable = false)
+    private Integer retryCount = 0;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    private LocalDateTime sentAt;
+
+    @Builder
+    public OutboxMessage(String id, String aggregateType, Long aggregateId, String payload) {
+        this.id = id;
+        this.aggregateType = aggregateType;
+        this.aggregateId = aggregateId;
+        this.payload = payload;
+        this.status = OutboxMessageStatus.PENDING;
+        this.retryCount = 0;
+    }
+
+    public void markAsSent() {
+        this.status = OutboxMessageStatus.SENT;
+        this.sentAt = LocalDateTime.now();
+    }
+
+    public void markAsFailed() {
+        this.status = OutboxMessageStatus.FAILED;
+    }
+
+    public void incrementRetryCount() {
+        this.retryCount++;
+    }
+}

--- a/src/main/java/com/example/wait4eat/global/message/outbox/enums/OutboxMessageStatus.java
+++ b/src/main/java/com/example/wait4eat/global/message/outbox/enums/OutboxMessageStatus.java
@@ -1,0 +1,5 @@
+package com.example.wait4eat.global.message.outbox.enums;
+
+public enum OutboxMessageStatus {
+    PENDING, SENT, FAILED
+}

--- a/src/main/java/com/example/wait4eat/global/message/outbox/event/OutboxSavedEvent.java
+++ b/src/main/java/com/example/wait4eat/global/message/outbox/event/OutboxSavedEvent.java
@@ -1,0 +1,17 @@
+package com.example.wait4eat.global.message.outbox.event;
+
+import com.example.wait4eat.global.message.outbox.entity.OutboxMessage;
+import lombok.Getter;
+
+import java.io.Serializable;
+import java.util.List;
+
+@Getter
+public class OutboxSavedEvent implements Serializable {
+
+    private final List<OutboxMessage> messages;
+
+    public OutboxSavedEvent(List<OutboxMessage> messages) {
+        this.messages = messages;
+    }
+}

--- a/src/main/java/com/example/wait4eat/global/message/outbox/event/handler/OutboxSavedEventHandler.java
+++ b/src/main/java/com/example/wait4eat/global/message/outbox/event/handler/OutboxSavedEventHandler.java
@@ -1,0 +1,23 @@
+package com.example.wait4eat.global.message.outbox.event.handler;
+
+import com.example.wait4eat.global.message.outbox.event.OutboxSavedEvent;
+import com.example.wait4eat.global.message.outbox.service.OutboxProcessor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OutboxSavedEventHandler {
+
+    private final OutboxProcessor outboxProcessor;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(OutboxSavedEvent event) {
+        outboxProcessor.process(event.getMessages());
+    }
+}

--- a/src/main/java/com/example/wait4eat/global/message/outbox/repository/OutboxJdbcRepository.java
+++ b/src/main/java/com/example/wait4eat/global/message/outbox/repository/OutboxJdbcRepository.java
@@ -1,0 +1,34 @@
+package com.example.wait4eat.global.message.outbox.repository;
+
+import com.example.wait4eat.global.message.outbox.entity.OutboxMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class OutboxJdbcRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    private final String INSERT_SQL = """
+            INSERT INTO outbox_messages
+            (id, aggregate_type, aggregate_id, payload, status, retry_count, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, now())
+            """;
+
+    public void saveAll(List<OutboxMessage> outboxMessages) {
+        jdbcTemplate.batchUpdate(INSERT_SQL, outboxMessages, 1000,
+                ((ps, msg) -> {
+                    ps.setString(1, msg.getId());
+                    ps.setString(2, msg.getAggregateType());
+                    ps.setLong(3, msg.getAggregateId());
+                    ps.setString(4, msg.getPayload());
+                    ps.setString(5, msg.getStatus().name());
+                    ps.setInt(6, msg.getRetryCount());
+                }
+       ));
+    }
+}

--- a/src/main/java/com/example/wait4eat/global/message/outbox/repository/OutboxMessageRepository.java
+++ b/src/main/java/com/example/wait4eat/global/message/outbox/repository/OutboxMessageRepository.java
@@ -1,0 +1,32 @@
+package com.example.wait4eat.global.message.outbox.repository;
+
+import com.example.wait4eat.global.message.outbox.entity.OutboxMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface OutboxMessageRepository extends JpaRepository<OutboxMessage, String> {
+
+    @Query(value = """
+                SELECT * FROM outbox_messages
+                WHERE status = 'FAILED'
+                AND retry_count < :maxRetry
+                ORDER BY created_at ASC
+                LIMIT :limit
+            """,
+            nativeQuery = true)
+    List<OutboxMessage> findFailedOutboxByRetryCountLessThanOrderByCreatedAtDesc(int maxRetry, int limit);
+
+    @Modifying
+    @Query("UPDATE OutboxMessage o SET o.status = 'SENT', o.sentAt = :now WHERE o.id IN :ids")
+    int markAllAsSent(List<String> ids, LocalDateTime now);
+
+    @Modifying
+    @Query("UPDATE OutboxMessage o SET o.status = 'FAILED' WHERE o.id IN :ids")
+    int markAllAsFailed(List<String> ids);
+
+   // boolean existsByIdAndIsProcessed(String messageKey, boolean isProcessed);
+}

--- a/src/main/java/com/example/wait4eat/global/message/outbox/service/OutboxProcessor.java
+++ b/src/main/java/com/example/wait4eat/global/message/outbox/service/OutboxProcessor.java
@@ -1,0 +1,52 @@
+package com.example.wait4eat.global.message.outbox.service;
+
+import com.example.wait4eat.global.message.publisher.MessagePublisher;
+import com.example.wait4eat.global.message.outbox.entity.OutboxMessage;
+import com.example.wait4eat.global.message.outbox.repository.OutboxMessageRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 직접적으로 message publisher에 요청하는 역할
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OutboxProcessor {
+
+    private final MessagePublisher publisher;
+    private final OutboxMessageRepository outboxMessageRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void process(List<OutboxMessage> messages) {
+
+        List<String> successIds = new ArrayList<>();
+        List<String> failedIds = new ArrayList<>();
+
+        for (OutboxMessage message : messages) {
+            try {
+                String payload = message.getPayload();
+                publisher.publish(payload);
+                successIds.add(message.getId());
+            } catch (Exception e) {
+                failedIds.add(message.getId());
+                log.warn("즉시 발송 실패: type={}, reason={}",
+                        message.getAggregateType(), e.getMessage());
+            }
+        }
+
+        if (!successIds.isEmpty()) {
+            outboxMessageRepository.markAllAsSent(successIds, LocalDateTime.now());
+        }
+        if (!failedIds.isEmpty()) {
+            outboxMessageRepository.markAllAsFailed(failedIds);
+        }
+    }
+}

--- a/src/main/java/com/example/wait4eat/global/message/outbox/service/OutboxService.java
+++ b/src/main/java/com/example/wait4eat/global/message/outbox/service/OutboxService.java
@@ -1,0 +1,72 @@
+package com.example.wait4eat.global.message.outbox.service;
+
+import com.example.wait4eat.global.message.payload.MessagePayload;
+import com.example.wait4eat.global.message.payload.NotificationPayload;
+import com.example.wait4eat.global.message.outbox.entity.OutboxMessage;
+import com.example.wait4eat.global.message.outbox.repository.OutboxJdbcRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OutboxService {
+
+    private final ObjectMapper objectMapper;
+    private final OutboxJdbcRepository outboxJdbcRepository;
+
+    @Transactional
+    public List<OutboxMessage> createNotificationOutboxes(List<NotificationPayload> notificationPayloads) {
+        List<OutboxMessage> messages = new ArrayList<>();
+
+        for (NotificationPayload notificationPayload : notificationPayloads) {
+            try {
+                String payload = objectMapper.writeValueAsString(notificationPayload);
+                messages.add(
+                        OutboxMessage.builder()
+                                .id(notificationPayload.getMessageKey())
+                                .aggregateId(notificationPayload.getTargetUserId())
+                                .aggregateType("NOTIFICATION")
+                                .payload(payload)
+                                .build()
+                );
+            } catch (JsonProcessingException e) {
+                log.warn("[OUTBOX 직렬화 실패] notificationId={}, reason={}", notificationPayload.getTargetUserId(), e.getMessage());
+            }
+        }
+
+        outboxJdbcRepository.saveAll(messages);
+        return messages;
+    }
+
+    @Transactional
+    public List<OutboxMessage> createEventOutboxes(List<MessagePayload> messagePayloads) {
+        List<OutboxMessage> messages = new ArrayList<>();
+
+        for (MessagePayload messagePayload : messagePayloads) {
+            try {
+                String payload = objectMapper.writeValueAsString(messagePayload);
+                messages.add(
+                        OutboxMessage.builder()
+                                .id(messagePayload.getMessageKey())
+                                .aggregateId(null)
+                                .aggregateType("EVENT")
+                                .payload(payload)
+                                .build()
+                );
+            } catch (JsonProcessingException e) {
+                log.warn("[OUTBOX 직렬화 실패] reason={}", e.getMessage());
+            }
+        }
+
+        outboxJdbcRepository.saveAll(messages);
+        return messages;
+    }
+}

--- a/src/main/java/com/example/wait4eat/global/message/payload/MessagePayload.java
+++ b/src/main/java/com/example/wait4eat/global/message/payload/MessagePayload.java
@@ -1,0 +1,5 @@
+package com.example.wait4eat.global.message.payload;
+
+public interface MessagePayload {
+    String getMessageKey();
+}

--- a/src/main/java/com/example/wait4eat/global/message/payload/NotificationPayload.java
+++ b/src/main/java/com/example/wait4eat/global/message/payload/NotificationPayload.java
@@ -1,0 +1,27 @@
+package com.example.wait4eat.global.message.payload;
+
+import com.example.wait4eat.domain.notification.enums.NotificationType;
+import com.example.wait4eat.global.util.IdGenerator;
+import lombok.Getter;
+
+@Getter
+public class NotificationPayload implements MessagePayload {
+
+    private final String messageKey;
+    private final Long notificationId;
+    private final Long targetUserId;
+    private final NotificationType notificationType;
+    private final String message;
+
+    public NotificationPayload(String messageKey, Long notificationId, Long targetUserId, NotificationType notificationType, String message) {
+        this.messageKey = messageKey;
+        this.notificationId = notificationId;
+        this.targetUserId = targetUserId;
+        this.notificationType = notificationType;
+        this.message = message;
+    }
+
+    public String getMessageKey() {
+        return this.messageKey;
+    }
+}

--- a/src/main/java/com/example/wait4eat/global/message/publisher/MessagePublisher.java
+++ b/src/main/java/com/example/wait4eat/global/message/publisher/MessagePublisher.java
@@ -1,0 +1,5 @@
+package com.example.wait4eat.global.message.publisher;
+
+public interface MessagePublisher {
+    void publish(String message);
+}

--- a/src/main/java/com/example/wait4eat/global/message/service/MessageStagingService.java
+++ b/src/main/java/com/example/wait4eat/global/message/service/MessageStagingService.java
@@ -1,0 +1,43 @@
+package com.example.wait4eat.global.message.service;
+
+import com.example.wait4eat.domain.notification.entity.Notification;
+import com.example.wait4eat.domain.notification.service.NotificationService;
+import com.example.wait4eat.global.message.dto.NotificationMessagePublishRequest;
+import com.example.wait4eat.global.message.outbox.entity.OutboxMessage;
+import com.example.wait4eat.global.message.outbox.service.OutboxService;
+import com.example.wait4eat.global.message.payload.NotificationPayload;
+import com.example.wait4eat.global.util.IdGenerator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class MessageStagingService {
+
+    private final NotificationService notificationService;
+    private final OutboxService outboxService;
+
+    @Transactional
+    public List<OutboxMessage> stage(NotificationMessagePublishRequest request) {
+        List<Notification> notifications =
+                notificationService.createBulk(request.getTargetUsers(), request.getNotificationType(), request.getMessage());
+
+        List<NotificationPayload> payloads = notifications.stream()
+                .map(notification -> new NotificationPayload(
+                        IdGenerator.generateMessageId(),
+                        notification.getId(),
+                        notification.getUser().getId(),
+                        notification.getType(),
+                        notification.getText()
+                ))
+                .toList();
+
+        // Outbox 저장
+        List<OutboxMessage> outboxes = outboxService.createNotificationOutboxes(payloads);
+
+        return outboxes;
+    }
+}

--- a/src/main/java/com/example/wait4eat/global/message/service/NotificationMessageProcessor.java
+++ b/src/main/java/com/example/wait4eat/global/message/service/NotificationMessageProcessor.java
@@ -1,0 +1,22 @@
+package com.example.wait4eat.global.message.service;
+
+import com.example.wait4eat.domain.notification.publisher.NotificationPublisher;
+import com.example.wait4eat.global.message.dedup.MessageDeduplicationHandler;
+import com.example.wait4eat.global.message.payload.NotificationPayload;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationMessageProcessor {
+
+    private final NotificationPublisher notificationPublisher;
+    private final MessageDeduplicationHandler messageDeduplicationHandler;
+
+    @Transactional
+    public void handleNotificationPublish(NotificationPayload payload) {
+        notificationPublisher.publish(payload);
+        messageDeduplicationHandler.markAsProcessed(payload.getMessageKey());
+    }
+}

--- a/src/main/java/com/example/wait4eat/global/util/IdGenerator.java
+++ b/src/main/java/com/example/wait4eat/global/util/IdGenerator.java
@@ -1,0 +1,17 @@
+package com.example.wait4eat.global.util;
+
+import java.util.UUID;
+
+public class IdGenerator {
+
+    private IdGenerator() { }
+
+    public static String generateMessageId() {
+        return UUID.randomUUID().toString();
+    }
+
+    public static long generateNotificationId() {
+        return System.nanoTime();
+    }
+
+}

--- a/src/main/java/com/example/wait4eat/infra/sqs/config/SqsConfig.java
+++ b/src/main/java/com/example/wait4eat/infra/sqs/config/SqsConfig.java
@@ -1,0 +1,54 @@
+package com.example.wait4eat.infra.sqs.config;
+
+import io.awspring.cloud.sqs.config.SqsMessageListenerContainerFactory;
+import io.awspring.cloud.sqs.listener.acknowledgement.handler.AcknowledgementMode;
+import io.awspring.cloud.sqs.operations.SqsTemplate;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+
+import java.time.Duration;
+
+@Configuration
+public class SqsConfig {
+
+    @Value("${spring.cloud.aws.credentials.access-key}")
+    private String accessKey;
+    @Value("${spring.cloud.aws.credentials.secret-key}")
+    private String secretKey;
+    @Value("${spring.cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public SqsAsyncClient sqsAsyncClient() {
+        return SqsAsyncClient.builder()
+                .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey)))
+                .region(Region.of(region))
+                .build();
+    }
+
+    @Bean
+    public SqsTemplate sqsTemplate() {
+        return SqsTemplate.newTemplate(sqsAsyncClient());
+    }
+
+    @Bean
+    public SqsMessageListenerContainerFactory<Object> defaultSqsListenerContainerFactory() {
+        return SqsMessageListenerContainerFactory
+                .builder()
+                .configure(sqsContainerOptionsBuilder ->
+                        sqsContainerOptionsBuilder
+                                .maxConcurrentMessages(10) // 컨테이너의 스레드 풀 크기
+                                .maxMessagesPerPoll(10) // 한 번의 폴링 요청으로 수신할 수 있는 최대 메시지 수를 지정
+                                .acknowledgementInterval(Duration.ofSeconds(5)) // AWS SQS 응답 간격
+                                .acknowledgementThreshold(10) // AWS SQS 응답 최소 개수
+                                .acknowledgementMode(AcknowledgementMode.ON_SUCCESS) // 소비 성공 시에만 ACK
+                )
+                .sqsAsyncClient(sqsAsyncClient())
+                .build();
+    }
+}

--- a/src/main/java/com/example/wait4eat/infra/sqs/listener/NotificationMessageListener.java
+++ b/src/main/java/com/example/wait4eat/infra/sqs/listener/NotificationMessageListener.java
@@ -1,0 +1,40 @@
+package com.example.wait4eat.infra.sqs.listener;
+
+import com.example.wait4eat.global.message.dedup.MessageDeduplicationHandler;
+import com.example.wait4eat.global.message.payload.NotificationPayload;
+import com.example.wait4eat.global.message.service.NotificationMessageProcessor;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.awspring.cloud.sqs.annotation.SqsListener;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationMessageListener {
+
+    @Value("${queue.notification.general}")
+    private String queueName;
+    private final ObjectMapper objectMapper;
+    private final MessageDeduplicationHandler messageDeduplicationHandler;
+    private final NotificationMessageProcessor notificationMessageProcessor;
+
+    @SqsListener("${queue.notification.general}")
+    public void receive(String rawMessage) {
+        try {
+            NotificationPayload payload =
+                    objectMapper.readValue(rawMessage, NotificationPayload.class);
+
+            if (messageDeduplicationHandler.isDuplicated(payload.getMessageKey())) {
+                return; // 중복 메시지 무시
+            }
+
+            notificationMessageProcessor.handleNotificationPublish(payload);
+        } catch (Exception e) {
+            log.error("메시지 처리 실패: {}", rawMessage, e);
+            throw new RuntimeException("재시도 유도용 예외", e);
+        }
+    }
+}

--- a/src/main/java/com/example/wait4eat/infra/sqs/publisher/SqsMessagePublisher.java
+++ b/src/main/java/com/example/wait4eat/infra/sqs/publisher/SqsMessagePublisher.java
@@ -1,0 +1,21 @@
+package com.example.wait4eat.infra.sqs.publisher;
+
+import com.example.wait4eat.global.message.publisher.MessagePublisher;
+import io.awspring.cloud.sqs.operations.SqsTemplate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SqsMessagePublisher implements MessagePublisher {
+
+    @Value("${spring.cloud.aws.sqs.endpoint}")
+    private String endpoint;
+    private final SqsTemplate sqsTemplate;
+
+    @Override
+    public void publish(String payload) {
+        sqsTemplate.send(endpoint, payload);
+    }
+}

--- a/src/main/java/com/example/wait4eat/scheduler/OutboxRetryScheduler.java
+++ b/src/main/java/com/example/wait4eat/scheduler/OutboxRetryScheduler.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -21,6 +22,7 @@ public class OutboxRetryScheduler { // TODO : 여러 인스턴스에서 동시�
     private static final int MAX_RETRY_COUNT = 3;
     private static final int BATCH_SIZE = 100;
 
+    @Transactional
     @Scheduled(fixedRate = 10000)
     public void retry() {
         List<OutboxMessage> messages = outboxMessageRepository
@@ -39,9 +41,8 @@ public class OutboxRetryScheduler { // TODO : 여러 인스턴스에서 동시�
                 log.info("재발송 성공: id={}", message.getId());
                 message.markAsSent();
             } catch (Exception e) {
-                message.markAsFailed();
                 message.incrementRetryCount();
-                log.warn("재발송 실패: type={}, aggregateId={}, reason={}",
+                log.warn("메세지 큐 재발송 실패: type={}, aggregateId={}, reason={}",
                         message.getAggregateType(), message.getAggregateId(), e.getMessage());
             }
         }

--- a/src/main/java/com/example/wait4eat/scheduler/OutboxRetryScheduler.java
+++ b/src/main/java/com/example/wait4eat/scheduler/OutboxRetryScheduler.java
@@ -1,0 +1,51 @@
+package com.example.wait4eat.scheduler;
+
+import com.example.wait4eat.global.message.publisher.MessagePublisher;
+import com.example.wait4eat.global.message.outbox.entity.OutboxMessage;
+import com.example.wait4eat.global.message.outbox.repository.OutboxMessageRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OutboxRetryScheduler { // TODO : 여러 인스턴스에서 동시에 수행되지 않도록 Shed Lock 적용 필요
+
+    private final OutboxMessageRepository outboxMessageRepository;
+    private final MessagePublisher messagePublisher;
+
+    private static final int MAX_RETRY_COUNT = 3;
+    private static final int BATCH_SIZE = 100;
+
+    @Scheduled(fixedRate = 10000)
+    public void retry() {
+        List<OutboxMessage> messages = outboxMessageRepository
+                .findFailedOutboxByRetryCountLessThanOrderByCreatedAtDesc(
+                        MAX_RETRY_COUNT,
+                        BATCH_SIZE
+                );
+
+        if(messages.isEmpty()) return;
+
+        log.info("[Outbox 재시도 시작] count={}", messages.size());
+
+        for (OutboxMessage message : messages) {
+            try {
+                messagePublisher.publish(message.getPayload());
+                log.info("재발송 성공: id={}", message.getId());
+                message.markAsSent();
+            } catch (Exception e) {
+                message.markAsFailed();
+                message.incrementRetryCount();
+                log.warn("재발송 실패: type={}, aggregateId={}, reason={}",
+                        message.getAggregateType(), message.getAggregateId(), e.getMessage());
+            }
+        }
+
+        outboxMessageRepository.saveAll(messages);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -44,3 +44,6 @@ spring.cloud.aws.sqs.endpoint=notification-general
 management.endpoints.web.exposure.include=*
 
 queue.notification.general=notification-general
+
+# Slack
+#slack.web-hook-url=

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -34,3 +34,13 @@ aws.s3.region=ap-northeast-2
 spring.servlet.multipart.file-size-threshold=1MB
 spring.servlet.multipart.max-file-size=2MB
 spring.servlet.multipart.max-request-size=10MB
+
+# AWS SQS
+spring.cloud.aws.region.static=ap-northeast-2
+#spring.cloud.aws.credentials.access-key=
+#spring.cloud.aws.credentials.secret-key=
+spring.cloud.aws.sqs.endpoint=notification-general
+
+management.endpoints.web.exposure.include=*
+
+queue.notification.general=notification-general


### PR DESCRIPTION
## 🧩 연관된 이슈

#85 , #86

## ✅ 작업 내용
- AWS SQS를 도입하여 알림 시스템을 재구성하였습니다.
- Outbox, Inbox 테이블이 추가되었습니다.
- Notification 테이블의 Id 생성 전략이 `GenerationType.IDENTITY`에서 직접 생성으로 변경되었습니다.
- Slack webhook을 연결하여 재처리 스케줄러에서 재처리 시도 한계를 초과한 메시지는 Slack 알림을 전송하도록 하였습니다.
 
## 📷 테스트
- 쿠폰 이벤트 발행 요청을 Postman으로 보내 정상적으로 CouponEvent, Notificaiton, Outbox, Inbox가 저장됨을 확인
- 임의로 SQS 발행 시 50% 확률로 예외를 발생시켜 재처리 스케줄러 가동 확인, 재처리 스케줄러에 의해 차후 모두 발행됨을 확인
- 임의로 재처리 스케줄러에서 80% 확률로 예외를 발생시켜 재처리 시도 한계를 초과하도록 한 뒤, Slack으로 알림이 전송됨을 확인
<img width="921" alt="Screenshot 2025-04-24 at 12 02 55" src="https://github.com/user-attachments/assets/c01ed486-0e14-4c47-ba41-9fd09fd8ea4f" />

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
