### PR TITLE
[#80] 쿠폰이벤트 발급 API 동시성 제어 추가_ lock timeout 설정

### DIFF
--- a/src/main/java/com/example/wait4eat/domain/coupon_event/dto/request/CreateCouponEventRequest.java
+++ b/src/main/java/com/example/wait4eat/domain/coupon_event/dto/request/CreateCouponEventRequest.java
@@ -5,11 +5,13 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import lombok.Getter;
+import lombok.Setter;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 @Getter
+@Setter
 public class CreateCouponEventRequest {
 
     @NotBlank(message = "쿠폰 이름은 필수입니다.")

--- a/src/main/java/com/example/wait4eat/domain/coupon_event/service/CouponEventService.java
+++ b/src/main/java/com/example/wait4eat/domain/coupon_event/service/CouponEventService.java
@@ -11,6 +11,8 @@ import com.example.wait4eat.domain.store.repository.StoreRepository;
 import com.example.wait4eat.global.auth.dto.AuthUser;
 import com.example.wait4eat.global.exception.CustomException;
 import com.example.wait4eat.global.exception.ExceptionType;
+import jakarta.persistence.LockTimeoutException;
+import jakarta.persistence.PessimisticLockException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -32,34 +34,39 @@ public class CouponEventService {
             Long storeId,
             CreateCouponEventRequest request
     ) {
-        Store store = storeRepository.findById(storeId).orElseThrow(() -> new CustomException(ExceptionType.STORE_NOT_FOUND));
+        try {
+            // 락 걸고 가게 조회
+            Store store = storeRepository.findByIdWithPessimisticLock(storeId).orElseThrow(() -> new CustomException(ExceptionType.STORE_NOT_FOUND));
 
-        // 본인의 가게인지 검증
-        if (!store.getUser().getId().equals(authUser.getUserId())) {
-            throw new CustomException(ExceptionType.STORE_NOT_MATCH_USER);
+            // 본인의 가게인지 검증
+            if (!store.getUser().getId().equals(authUser.getUserId())) {
+                throw new CustomException(ExceptionType.STORE_NOT_MATCH_USER);
+            }
+
+            // 쿠폰이벤트는 한 번만 생성 가능(이미 진행 중인 쿠폰이벤트가 있으면 예외 처리, 1가게 1쿠폰이기에 storeId로 유무 검증)
+            boolean existsCouponEvent = couponEventRepository.existsByStoreId(storeId);
+            if (existsCouponEvent) {
+                throw new CustomException(ExceptionType.COUPON_EVENT_ALREADY_EXISTS);
+            }
+
+            CouponEvent couponEvent = CouponEvent.builder()
+                    .store(store)
+                    .name(request.getName())
+                    .discountAmount(request.getDiscountAmount())
+                    .totalQuantity(request.getTotalQuantity())
+                    .issuedQuantity(0)
+                    .expiresAt(request.getExpiresAt())
+                    .createdAt(LocalDateTime.now())
+                    .build();
+
+            CouponEvent savedCouponEvent = couponEventRepository.save(couponEvent);
+
+            eventPublisher.publishEvent(CouponEventLaunchedEvent.of(store, savedCouponEvent));
+
+            return CreateCouponEventResponse.from(savedCouponEvent);
+        } catch (PessimisticLockException | LockTimeoutException e) {
+            throw new CustomException(ExceptionType.DATABASE_LOCK_FAILED);
         }
-
-        // 쿠폰이벤트는 한 번만 생성 가능(이미 진행 중인 쿠폰이벤트가 있으면 예외 처리, 1가게 1쿠폰이기에 storeId로 유무 검증)
-        boolean existsCouponEvent = couponEventRepository.existsByStoreId(storeId);
-        if (existsCouponEvent) {
-            throw new CustomException(ExceptionType.COUPON_EVENT_ALREADY_EXISTS);
-        }
-
-        CouponEvent couponEvent = CouponEvent.builder()
-                .store(store)
-                .name(request.getName())
-                .discountAmount(request.getDiscountAmount())
-                .totalQuantity(request.getTotalQuantity())
-                .issuedQuantity(0)
-                .expiresAt(request.getExpiresAt())
-                .createdAt(LocalDateTime.now())
-                .build();
-
-        CouponEvent savedCouponEvent = couponEventRepository.save(couponEvent);
-
-        eventPublisher.publishEvent(CouponEventLaunchedEvent.of(store, savedCouponEvent));
-
-        return CreateCouponEventResponse.from(savedCouponEvent);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/example/wait4eat/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/example/wait4eat/domain/store/repository/StoreRepository.java
@@ -1,12 +1,21 @@
 package com.example.wait4eat.domain.store.repository;
 
 import com.example.wait4eat.domain.store.entity.Store;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface StoreRepository extends JpaRepository<Store, Long> {
     boolean existsByUserId (Long userId);
 
     Page<Store> findAll(Pageable pageable);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select s from Store s where s.id = :storeId")
+    Optional<Store> findByIdWithPessimisticLock(Long storeId);
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -49,4 +49,4 @@ queue.notification.general=notification-general
 #slack.web-hook-url=
 
 # lock timeout
-spring.jpa.properties.javax.persistence.lock.timeout=3000
+spring.jpa.properties.jakarta.persistence.lock.timeout=3000

--- a/src/test/java/com/example/wait4eat/domain/coupon_event/integration/CouponEventConcurrencyTest.java
+++ b/src/test/java/com/example/wait4eat/domain/coupon_event/integration/CouponEventConcurrencyTest.java
@@ -1,0 +1,118 @@
+package com.example.wait4eat.domain.coupon_event.integration;
+
+import com.example.wait4eat.domain.coupon_event.dto.request.CreateCouponEventRequest;
+import com.example.wait4eat.domain.coupon_event.repository.CouponEventRepository;
+import com.example.wait4eat.domain.coupon_event.service.CouponEventService;
+import com.example.wait4eat.domain.store.entity.Store;
+import com.example.wait4eat.domain.store.repository.StoreRepository;
+import com.example.wait4eat.domain.user.entity.User;
+import com.example.wait4eat.domain.user.enums.UserRole;
+import com.example.wait4eat.domain.user.repository.UserRepository;
+import com.example.wait4eat.global.auth.dto.AuthUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("local")
+class CouponEventConcurrencyTest {
+
+    @Autowired
+    private CouponEventService couponEventService;
+
+    @Autowired
+    private CouponEventRepository couponEventRepository;
+
+    @Autowired
+    private StoreRepository storeRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private Long storeId;
+    private AuthUser authUser;
+
+    @BeforeEach
+    void setUp() {
+        // 1. 테스트 사장 1명 생성
+        User storeOwner = User.builder()
+                .email("owner@example.com")
+                .nickname("김사장")
+                .password(passwordEncoder.encode("Test1234!"))
+                .role(UserRole.valueOf("ROLE_OWNER"))
+                .build();
+
+        userRepository.save(storeOwner);
+
+        // 2. 테스트 사장의 스토어 생성
+        Store store = Store.builder()
+                .user(storeOwner)
+                .name("테스트 가게")
+                .address("서울시 테스트구 테스트동")
+                .openTime(LocalTime.of(9, 0))
+                .closeTime(LocalTime.of(22, 0))
+                .description("테스트용 가게입니다.")
+                .depositAmount(10000)
+                .build();
+
+        storeRepository.save(store);
+        storeId = store.getId();
+
+        authUser = new AuthUser(storeOwner.getId(), storeOwner.getEmail(), storeOwner.getRole());
+    }
+
+    @Test
+    void 한_명의_사장이_동시에_여러_번_쿠폰이벤트를_생성해도_오직_하나만_성공해야_한다() throws InterruptedException {
+        int threadCount = 100;
+        ExecutorService executorService = Executors.newFixedThreadPool(10);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failCount = new AtomicInteger(0);
+
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    CreateCouponEventRequest request = new CreateCouponEventRequest();
+                    request.setName("테스트 쿠폰");
+                    request.setDiscountAmount(BigDecimal.valueOf(2000));
+                    request.setTotalQuantity(10);
+                    request.setExpiresAt(LocalDateTime.now().plusDays(1));
+
+                    couponEventService.createCouponEvent(authUser, storeId, request);
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failCount.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        long totalCreated = couponEventRepository.count();
+
+        assertEquals(1, totalCreated, "쿠폰이벤트는 1개만 생성되어야 합니다");
+        assertEquals(1, successCount.get(), "성공한 요청은 정확히 1개여야 합니다");
+        assertEquals(threadCount - 1, failCount.get(), "나머지는 실패해야 합니다");
+
+        System.out.println("총 생성된 쿠폰이벤트 수: " + totalCreated);
+        System.out.println("총 스레드 작업 수: " + threadCount + ", 성공 요청 수: " + successCount.get() + ", 실패 요청 수: " + failCount.get());
+    }
+}


### PR DESCRIPTION
## 🧩 연관된 이슈

> #80 

## ✅ 작업 내용

> 한 명의 사장이 쿠폰이벤트 발급 API를 동시에 여러 번 호출할 경우, 동일한 쿠폰이벤트가 중복으로 발급되는 문제 발생
- 비관적 락을 사용한 동시성 제어
 
## 📷 테스트

> 동시성 제어 테스트 코드 구현
- 한 명의 사장이 동시에 여러 번 쿠폰이벤트를 생성해도 오직 하나만 성공해야 한다.

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

