### PR TITLE
ES 도입하여 검색 기능 고도화 완료 #62, #67, #78

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+elasticsearch.http

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ out/
 .vscode/
 
 elasticsearch.http
+
+### application.properties
+**/application-test.properties

--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,13 @@ dependencies {
 
     // Retry
     implementation 'org.springframework.retry:spring-retry'
+
+    // AWS S3
+    implementation 'software.amazon.awssdk:s3:2.20.134'
+
+    // ElasticSearch
+    implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,6 @@ dependencies {
 
     // ElasticSearch
     implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
-
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/wait4eat/domain/store/controller/StoreController.java
+++ b/src/main/java/com/example/wait4eat/domain/store/controller/StoreController.java
@@ -1,6 +1,7 @@
 package com.example.wait4eat.domain.store.controller;
 
 import com.example.wait4eat.domain.store.dto.request.CreateStoreRequest;
+import com.example.wait4eat.domain.store.dto.request.SearchStoreRequest;
 import com.example.wait4eat.domain.store.dto.response.CreateStoreResponse;
 import com.example.wait4eat.domain.store.dto.response.GetStoreDetailResponse;
 import com.example.wait4eat.domain.store.dto.response.GetStoreListResponse;
@@ -38,10 +39,9 @@ public class StoreController {
 
     @GetMapping("/api/v1/stores")
     public ResponseEntity<PageResponse<GetStoreListResponse>> getStoreList(
-            @PageableDefault(page = 0, size = 10, sort = "createdAt", direction = Sort.Direction.DESC)
-            Pageable pageable
-    ) {
-        return ResponseEntity.ok(PageResponse.from(storeService.getStoreList(pageable)));
+            @ModelAttribute SearchStoreRequest request
+            ) {
+        return ResponseEntity.ok(PageResponse.from(storeService.getStoreList(request)));
     }
 
     @GetMapping("/api/v1/stores/{storeId}")
@@ -51,4 +51,8 @@ public class StoreController {
         return ResponseEntity.ok(SuccessResponse.from(storeService.getStoreDetail(storeId)));
     }
 
+    @GetMapping("/api/v1/stores/debug")
+    public SearchStoreRequest debug(@ModelAttribute SearchStoreRequest request) {
+        return request;
+    }
 }

--- a/src/main/java/com/example/wait4eat/domain/store/controller/StoreController.java
+++ b/src/main/java/com/example/wait4eat/domain/store/controller/StoreController.java
@@ -44,6 +44,13 @@ public class StoreController {
         return ResponseEntity.ok(PageResponse.from(storeService.getStoreList(request)));
     }
 
+    @GetMapping("api/v1/stores/es")
+    public ResponseEntity<PageResponse<GetStoreListResponse>> searchByEs(
+            @ModelAttribute SearchStoreRequest request
+    ) {
+        return ResponseEntity.ok(PageResponse.from(storeService.getStoreListByEs(request)));
+    }
+
     @GetMapping("/api/v1/stores/{storeId}")
     public ResponseEntity<SuccessResponse<GetStoreDetailResponse>> getStoreDetail(
             @PathVariable Long storeId

--- a/src/main/java/com/example/wait4eat/domain/store/dto/request/SearchStoreRequest.java
+++ b/src/main/java/com/example/wait4eat/domain/store/dto/request/SearchStoreRequest.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalTime;
 
@@ -16,7 +17,11 @@ public class SearchStoreRequest {
     private String name; // 가게 이름 (like 검색)
     private String address; // 주소 (like 검색)
     private String description; // 설명 (like 검색)
+
+    @DateTimeFormat(pattern = "HH:mm")
     private LocalTime openTime; // 오픈 시간 (필터링)
+
+    @DateTimeFormat(pattern = "HH:mm")
     private LocalTime closeTime; // 마감 시간 (필터링)
 
     // 페이징 정보

--- a/src/main/java/com/example/wait4eat/domain/store/dto/request/SearchStoreRequest.java
+++ b/src/main/java/com/example/wait4eat/domain/store/dto/request/SearchStoreRequest.java
@@ -1,0 +1,70 @@
+package com.example.wait4eat.domain.store.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Pattern;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalTime;
+
+@Getter
+@Setter
+public class SearchStoreRequest {
+
+    // 검색 조건
+    private String name; // 가게 이름 (like 검색)
+    private String address; // 주소 (like 검색)
+    private String description; // 설명 (like 검색)
+    private LocalTime openTime; // 오픈 시간 (필터링)
+    private LocalTime closeTime; // 마감 시간 (필터링)
+
+    // 페이징 정보
+    @Min(value = 0, message = "page는 0 이상이어야 합니다.")
+    private int page = 0; // 기본값: 0
+
+    @Min(value = 1, message = "size는 1 이상이어야 합니다.")
+    private int size = 10; // 기본값: 10
+
+    // 정렬 정보
+    @Pattern(regexp = "createdAt|depositAmount|waitingTeamCount",
+            message = "sort는 createdAt, depositAmount, waitingTeamCount 중 하나여야 합니다.")
+    private String sort = "createdAt"; // 기본 정렬 필드 (depositAmount, waitingTeamCount 등 가능)
+
+    @Pattern(regexp = "asc|desc",
+            message = "sortDirection은 asc 또는 desc이어야 합니다.")
+    private String sortDirection = "desc"; // 기본 정렬 방향 (asc, desc 가능)
+
+    @Builder
+    public SearchStoreRequest(
+            String name,
+            String address,
+            String description,
+            LocalTime openTime,
+            LocalTime closeTime,
+            Integer page,
+            Integer size,
+            String sort,
+            String sortDirection
+    ) {
+        System.out.println("Building SearchStoreRequest: name=" + name); // 디버깅 로그
+        this.name = name;
+        this.address = address;
+        this.description = description;
+        this.openTime = openTime;
+        this.closeTime = closeTime;
+        this.page = page != null ? page : 0;
+        this.size = size != null ? size : 10;
+        this.sort = sort != null ? sort : "createdAt";
+        this.sortDirection = sortDirection != null ? sortDirection : "desc";
+    }
+
+    // 기본 생성자 (빌더 패턴과 함께 사용 가능하도록)
+    public SearchStoreRequest() {
+        System.out.println("Default constructor called");
+        this.page = 0;
+        this.size = 10;
+        this.sort = "createdAt";
+        this.sortDirection = "desc";
+    }
+}

--- a/src/main/java/com/example/wait4eat/domain/store/dto/response/GetStoreListResponse.java
+++ b/src/main/java/com/example/wait4eat/domain/store/dto/response/GetStoreListResponse.java
@@ -53,7 +53,6 @@ public class GetStoreListResponse {
                 .openTime(LocalTime.parse(storeDocument.getOpenTime()))
                 .closeTime(LocalTime.parse(storeDocument.getCloseTime()))
                 .depositAmount(storeDocument.getDepositAmount())
-                .waitingTeamCount(storeDocument.getWaitingTeamCount())
                 .build();
     }
 }

--- a/src/main/java/com/example/wait4eat/domain/store/dto/response/GetStoreListResponse.java
+++ b/src/main/java/com/example/wait4eat/domain/store/dto/response/GetStoreListResponse.java
@@ -1,6 +1,7 @@
 package com.example.wait4eat.domain.store.dto.response;
 
 import com.example.wait4eat.domain.store.entity.Store;
+import com.example.wait4eat.domain.store.entity.StoreDocument;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -41,6 +42,18 @@ public class GetStoreListResponse {
                 .openTime(store.getOpenTime())
                 .closeTime(store.getCloseTime())
                 .depositAmount(store.getDepositAmount())
+                .build();
+    }
+
+    public static GetStoreListResponse from(StoreDocument storeDocument) {
+        return GetStoreListResponse.builder()
+                .id(storeDocument.getId())
+                .name(storeDocument.getName())
+                .address(storeDocument.getAddress())
+                .openTime(LocalTime.parse(storeDocument.getOpenTime()))
+                .closeTime(LocalTime.parse(storeDocument.getCloseTime()))
+                .depositAmount(storeDocument.getDepositAmount())
+                .waitingTeamCount(storeDocument.getWaitingTeamCount())
                 .build();
     }
 }

--- a/src/main/java/com/example/wait4eat/domain/store/entity/StoreDocument.java
+++ b/src/main/java/com/example/wait4eat/domain/store/entity/StoreDocument.java
@@ -6,9 +6,9 @@ import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
 
-import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 
-@Document(indexName = "stores_index") // index 이름
+@Document(indexName = "stores") // index 이름
 @Getter
 @Setter
 @NoArgsConstructor
@@ -28,11 +28,11 @@ public class StoreDocument {
     @Field(type = FieldType.Text, analyzer = "korean_nori", searchAnalyzer = "korean_nori")
     private String description;
 
-    @Field(type = FieldType.Keyword, normalizer = "lowercase_normalizer")
-    private LocalTime openTime;
+    @Field(type = FieldType.Keyword)
+    private String openTime;
 
-    @Field(type = FieldType.Keyword, normalizer = "lowercase_normalizer")
-    private LocalTime closeTime;
+    @Field(type = FieldType.Keyword)
+    private String closeTime;
 
     @Field(type = FieldType.Integer)
     private int depositAmount;
@@ -46,8 +46,8 @@ public class StoreDocument {
                 .name(store.getName())
                 .address(store.getAddress())
                 .description(store.getDescription())
-                .openTime(store.getOpenTime())
-                .closeTime(store.getCloseTime())
+                .openTime(store.getOpenTime().format(DateTimeFormatter.ofPattern("HH:mm")))
+                .closeTime(store.getCloseTime().format(DateTimeFormatter.ofPattern("HH:mm")))
                 .depositAmount(store.getDepositAmount())
                 .waitingTeamCount(store.getWaitingTeamCount())
                 .build();

--- a/src/main/java/com/example/wait4eat/domain/store/entity/StoreDocument.java
+++ b/src/main/java/com/example/wait4eat/domain/store/entity/StoreDocument.java
@@ -1,0 +1,56 @@
+package com.example.wait4eat.domain.store.entity;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+import java.time.LocalTime;
+
+@Document(indexName = "stores_index") // index 이름
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class StoreDocument {
+
+    @Id
+    private Long id;
+
+    @Field(type = FieldType.Text, analyzer = "korean_nori", searchAnalyzer = "korean_nori")
+    private String name;
+
+    @Field(type = FieldType.Text, analyzer = "korean_nori", searchAnalyzer = "korean_nori")
+    private String address;
+
+    @Field(type = FieldType.Text, analyzer = "korean_nori", searchAnalyzer = "korean_nori")
+    private String description;
+
+    @Field(type = FieldType.Keyword, normalizer = "lowercase_normalizer")
+    private LocalTime openTime;
+
+    @Field(type = FieldType.Keyword, normalizer = "lowercase_normalizer")
+    private LocalTime closeTime;
+
+    @Field(type = FieldType.Integer)
+    private int depositAmount;
+
+    @Field(type = FieldType.Integer)
+    private int waitingTeamCount;
+
+    public static StoreDocument from(Store store) {
+        return StoreDocument.builder()
+                .id(store.getId())
+                .name(store.getName())
+                .address(store.getAddress())
+                .description(store.getDescription())
+                .openTime(store.getOpenTime())
+                .closeTime(store.getCloseTime())
+                .depositAmount(store.getDepositAmount())
+                .waitingTeamCount(store.getWaitingTeamCount())
+                .build();
+    }
+}
+

--- a/src/main/java/com/example/wait4eat/domain/store/entity/StoreDocument.java
+++ b/src/main/java/com/example/wait4eat/domain/store/entity/StoreDocument.java
@@ -49,7 +49,6 @@ public class StoreDocument {
                 .openTime(store.getOpenTime().format(DateTimeFormatter.ofPattern("HH:mm")))
                 .closeTime(store.getCloseTime().format(DateTimeFormatter.ofPattern("HH:mm")))
                 .depositAmount(store.getDepositAmount())
-                .waitingTeamCount(store.getWaitingTeamCount())
                 .build();
     }
 }

--- a/src/main/java/com/example/wait4eat/domain/store/repository/StoreBulkRepository.java
+++ b/src/main/java/com/example/wait4eat/domain/store/repository/StoreBulkRepository.java
@@ -35,7 +35,6 @@ public class StoreBulkRepository {
             ps.setTime(5, Time.valueOf(store.getCloseTime()));
             ps.setString(6, store.getDescription());
             ps.setInt(7, store.getDepositAmount());
-            ps.setInt(8, store.getWaitingTeamCount());
             ps.setTimestamp(9, Timestamp.valueOf(
                     store.getCreatedAt() != null ? store.getCreatedAt() : LocalDateTime.now()));
             ps.setTimestamp(10, Timestamp.valueOf(

--- a/src/main/java/com/example/wait4eat/domain/store/repository/StoreBulkRepository.java
+++ b/src/main/java/com/example/wait4eat/domain/store/repository/StoreBulkRepository.java
@@ -1,0 +1,45 @@
+package com.example.wait4eat.domain.store.repository;
+
+import lombok.RequiredArgsConstructor;
+import com.example.wait4eat.domain.store.entity.Store;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class StoreBulkRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    private static final int BATCH_SIZE = 1000;
+
+    public void bulkInsert(List<Store> stores) {
+        String sql = """
+            INSERT INTO stores (
+                user_id, name, address, open_time, close_time,
+                description, deposit_amount, waiting_team_count,
+                created_at, modified_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """;
+
+        jdbcTemplate.batchUpdate(sql, stores, BATCH_SIZE, (ps, store) -> {
+            ps.setLong(1, store.getUser().getId());
+            ps.setString(2, store.getName());
+            ps.setString(3, store.getAddress());
+            ps.setTime(4, Time.valueOf(store.getOpenTime()));
+            ps.setTime(5, Time.valueOf(store.getCloseTime()));
+            ps.setString(6, store.getDescription());
+            ps.setInt(7, store.getDepositAmount());
+            ps.setInt(8, store.getWaitingTeamCount());
+            ps.setTimestamp(9, Timestamp.valueOf(
+                    store.getCreatedAt() != null ? store.getCreatedAt() : LocalDateTime.now()));
+            ps.setTimestamp(10, Timestamp.valueOf(
+                    store.getModifiedAt() != null ? store.getModifiedAt() : LocalDateTime.now()));
+        });
+    }
+}

--- a/src/main/java/com/example/wait4eat/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/example/wait4eat/domain/store/repository/StoreRepository.java
@@ -24,8 +24,20 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
             "WHERE (:name IS NULL OR s.name LIKE %:name%) " +
             "AND (:address IS NULL OR s.address LIKE %:address%) " +
             "AND (:description IS NULL OR s.description LIKE %:description%) " +
-            "AND (:openTime IS NULL OR s.openTime >= :openTime) " +
-            "AND (:closeTime IS NULL OR s.closeTime <= :closeTime)")
+            "AND (" +
+            "    (:openTime IS NULL AND :closeTime IS NULL) OR " +
+            "    (" +
+            "        s.openTime < s.closeTime AND " +
+            "        (:openTime IS NULL OR s.openTime <= :openTime) AND " +
+            "        (:closeTime IS NULL OR s.closeTime >= :closeTime)" +
+            "    ) OR (" +
+            "        s.openTime > s.closeTime AND " +
+            "        (" +
+            "            (:openTime IS NULL OR s.openTime <= :openTime) OR " +
+            "            (:closeTime IS NULL OR s.closeTime >= :closeTime)" +
+            "        )" +
+            "    )" +
+            ")")
     Page<Store> searchStores(
             @Param("name") String name,
             @Param("address") String address,

--- a/src/main/java/com/example/wait4eat/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/example/wait4eat/domain/store/repository/StoreRepository.java
@@ -1,10 +1,15 @@
 package com.example.wait4eat.domain.store.repository;
 
+import com.example.wait4eat.domain.store.dto.request.SearchStoreRequest;
 import com.example.wait4eat.domain.store.entity.Store;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalTime;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 
@@ -14,6 +19,33 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
     boolean existsByUserId (Long userId);
 
     Page<Store> findAll(Pageable pageable);
+
+    @Query("SELECT s FROM Store s " +
+            "WHERE (:name IS NULL OR s.name LIKE %:name%) " +
+            "AND (:address IS NULL OR s.address LIKE %:address%) " +
+            "AND (:description IS NULL OR s.description LIKE %:description%) " +
+            "AND (:openTime IS NULL OR s.openTime >= :openTime) " +
+            "AND (:closeTime IS NULL OR s.closeTime <= :closeTime)")
+    Page<Store> searchStores(
+            @Param("name") String name,
+            @Param("address") String address,
+            @Param("description") String description,
+            @Param("openTime") LocalTime openTime,
+            @Param("closeTime") LocalTime closeTime,
+            Pageable pageable
+    );
+
+    // SearchStoreRequest를 직접 처리하도록 오버로드
+    default Page<Store> searchStores(SearchStoreRequest request, Pageable pageable) {
+        return searchStores(
+                request.getName(),
+                request.getAddress(),
+                request.getDescription(),
+                request.getOpenTime(),
+                request.getCloseTime(),
+                pageable
+        );
+    }
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select s from Store s where s.id = :storeId")

--- a/src/main/java/com/example/wait4eat/domain/store/repository/StoreSearchRepository.java
+++ b/src/main/java/com/example/wait4eat/domain/store/repository/StoreSearchRepository.java
@@ -1,0 +1,23 @@
+package com.example.wait4eat.domain.store.repository;
+
+import com.example.wait4eat.domain.store.entity.StoreDocument;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+import java.time.LocalTime;
+
+public interface StoreSearchRepository extends ElasticsearchRepository<StoreDocument, String> {
+
+    // 기본 검색: name.nori, address.nori, description.nori 필드 대상
+    Page<StoreDocument> findByNameContainingOrAddressContainingOrDescriptionContaining(
+            String name, String address, String description, Pageable pageable
+    );
+
+    // 시간 필터링 포함 검색
+    Page<StoreDocument> findByNameContainingOrAddressContainingOrDescriptionContainingAndOpenTimeGreaterThanEqualAndCloseTimeLessThanEqual(
+            String name, String address, String description,
+            LocalTime openTime, LocalTime closeTime, Pageable pageable
+    );
+}
+

--- a/src/main/java/com/example/wait4eat/domain/store/repository/StoreSearchRepositoryCustom.java
+++ b/src/main/java/com/example/wait4eat/domain/store/repository/StoreSearchRepositoryCustom.java
@@ -4,10 +4,7 @@ import com.example.wait4eat.domain.store.dto.request.SearchStoreRequest;
 import com.example.wait4eat.domain.store.entity.StoreDocument;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 
-public interface StoreSearchRepository extends ElasticsearchRepository<StoreDocument, String>, StoreSearchRepositoryCustom {
-
+public interface StoreSearchRepositoryCustom {
     Page<StoreDocument> searchStores(SearchStoreRequest request, Pageable pageable);
 }
-

--- a/src/main/java/com/example/wait4eat/domain/store/repository/StoreSearchRepositoryImpl.java
+++ b/src/main/java/com/example/wait4eat/domain/store/repository/StoreSearchRepositoryImpl.java
@@ -14,6 +14,7 @@ import org.springframework.data.elasticsearch.core.query.CriteriaQuery;
 import org.springframework.stereotype.Repository;
 import org.springframework.data.elasticsearch.core.query.Query;
 
+import java.time.format.DateTimeFormatter;
 import java.util.stream.Collectors;
 
 @Repository
@@ -28,6 +29,7 @@ public class StoreSearchRepositoryImpl implements StoreSearchRepositoryCustom {
     @Override
     public Page<StoreDocument> searchStores(SearchStoreRequest request, Pageable pageable) {
         Criteria criteria = new Criteria();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm");
 
         if (request.getName() != null && !request.getName().isEmpty()) {
             criteria.and(new Criteria("name").matches(request.getName()));
@@ -39,10 +41,12 @@ public class StoreSearchRepositoryImpl implements StoreSearchRepositoryCustom {
             criteria.and(new Criteria("description").matches(request.getDescription()));
         }
         if (request.getOpenTime() != null) {
-            criteria.and(new Criteria("openTime").greaterThanEqual(request.getOpenTime()));
+            String openTimeStr = request.getOpenTime().format(formatter);
+            criteria.and(new Criteria("openTime").greaterThanEqual(openTimeStr));
         }
         if (request.getCloseTime() != null) {
-            criteria.and(new Criteria("closeTime").lessThanEqual(request.getCloseTime()));
+            String closeTimeStr = request.getCloseTime().format(formatter);
+            criteria.and(new Criteria("closeTime").lessThanEqual(closeTimeStr));
         }
 
         Query query = new CriteriaQuery(criteria)

--- a/src/main/java/com/example/wait4eat/domain/store/repository/StoreSearchRepositoryImpl.java
+++ b/src/main/java/com/example/wait4eat/domain/store/repository/StoreSearchRepositoryImpl.java
@@ -15,12 +15,16 @@ import org.springframework.stereotype.Repository;
 import org.springframework.data.elasticsearch.core.query.Query;
 
 import java.time.format.DateTimeFormatter;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Repository
 public class StoreSearchRepositoryImpl implements StoreSearchRepositoryCustom {
 
     private final ElasticsearchOperations elasticsearchOperations;
+    private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm");
 
     public StoreSearchRepositoryImpl(ElasticsearchOperations elasticsearchOperations) {
         this.elasticsearchOperations = elasticsearchOperations;
@@ -29,8 +33,8 @@ public class StoreSearchRepositoryImpl implements StoreSearchRepositoryCustom {
     @Override
     public Page<StoreDocument> searchStores(SearchStoreRequest request, Pageable pageable) {
         Criteria criteria = new Criteria();
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm");
 
+        // 기본 검색 조건
         if (request.getName() != null && !request.getName().isEmpty()) {
             criteria.and(new Criteria("name").matches(request.getName()));
         }
@@ -40,26 +44,70 @@ public class StoreSearchRepositoryImpl implements StoreSearchRepositoryCustom {
         if (request.getDescription() != null && !request.getDescription().isEmpty()) {
             criteria.and(new Criteria("description").matches(request.getDescription()));
         }
-        if (request.getOpenTime() != null) {
-            String openTimeStr = request.getOpenTime().format(formatter);
-            criteria.and(new Criteria("openTime").greaterThanEqual(openTimeStr));
-        }
-        if (request.getCloseTime() != null) {
-            String closeTimeStr = request.getCloseTime().format(formatter);
-            criteria.and(new Criteria("closeTime").lessThanEqual(closeTimeStr));
+
+        // 시간 조건
+        if (request.getOpenTime() != null && request.getCloseTime() != null) {
+            String requestOpen = request.getOpenTime().format(formatter);
+            String requestClose = request.getCloseTime().format(formatter);
+
+            // openTime <= 요청 openTime
+            criteria.and(new Criteria("openTime").lessThanEqual(requestOpen));
+            // closeTime >= 요청 closeTime
+            criteria.and(new Criteria("closeTime").greaterThanEqual(requestClose));
+
+            // 자정 넘김(overnight) 케이스도 포함해야 함
+            // closeTime < openTime 인 경우(예: 18:00~02:00), closeTime에 24시간을 더해 비교
+            // Elasticsearch에 저장된 시간은 문자열이므로, 실제 비교는 애플리케이션에서 필터링 필요
+
+        } else if (request.getOpenTime() != null) {
+            String requestOpen = request.getOpenTime().format(formatter);
+            criteria.and(new Criteria("openTime").lessThanEqual(requestOpen));
+        } else if (request.getCloseTime() != null) {
+            String requestClose = request.getCloseTime().format(formatter);
+            criteria.and(new Criteria("closeTime").greaterThanEqual(requestClose));
         }
 
         Query query = new CriteriaQuery(criteria)
                 .setPageable(pageable)
-                .addSort(Sort.by(Sort.Order.desc("_score"))); // 점수 내림차순 정렬 추가
+                .addSort(Sort.by(Sort.Order.desc("_score")));
 
         SearchHits<StoreDocument> searchHits = elasticsearchOperations.search(query, StoreDocument.class);
-        return new PageImpl<>(
-                searchHits.getSearchHits().stream()
-                        .map(SearchHit::getContent)
-                        .collect(Collectors.toList()),
-                pageable,
-                searchHits.getTotalHits()
-        );
+        List<StoreDocument> results = searchHits.getSearchHits().stream()
+                .map(SearchHit::getContent)
+                .toList();
+
+        // overnight 케이스(자정 넘김) 추가 필터링
+        if (request.getOpenTime() != null && request.getCloseTime() != null) {
+            int reqOpen = request.getOpenTime().getHour() * 60 + request.getOpenTime().getMinute();
+            int reqClose = request.getCloseTime().getHour() * 60 + request.getCloseTime().getMinute();
+
+            results = results.stream().filter(doc -> {
+                int storeOpen = Integer.parseInt(doc.getOpenTime().replace(":", "")) / 100 * 60 +
+                        Integer.parseInt(doc.getOpenTime().replace(":", "")) % 100;
+                int storeClose = Integer.parseInt(doc.getCloseTime().replace(":", "")) / 100 * 60 +
+                        Integer.parseInt(doc.getCloseTime().replace(":", "")) % 100;
+
+                if (storeClose > storeOpen) {
+                    // 일반 케이스
+                    return storeOpen <= reqOpen && storeClose >= reqClose;
+                } else {
+                    // overnight 케이스 (예: 18:00~02:00)
+                    // closeTime에 24*60 더해서 비교
+                    int storeCloseOvernight = storeClose + 24 * 60;
+                    int reqCloseOvernight = reqClose < storeOpen ? reqClose + 24 * 60 : reqClose;
+                    return storeOpen <= reqOpen && storeCloseOvernight >= reqCloseOvernight;
+                }
+            }).collect(Collectors.toList());
+        }
+
+        // 중복 제거
+        Set<String> seenIds = new HashSet<>();
+        List<StoreDocument> uniqueResults = results.stream()
+                .filter(doc -> seenIds.add(String.valueOf(doc.getId())))
+                .collect(Collectors.toList());
+
+        long totalHits = uniqueResults.size();
+        return new PageImpl<>(uniqueResults, pageable, totalHits);
     }
+
 }

--- a/src/main/java/com/example/wait4eat/domain/store/repository/StoreSearchRepositoryImpl.java
+++ b/src/main/java/com/example/wait4eat/domain/store/repository/StoreSearchRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.example.wait4eat.domain.store.entity.StoreDocument;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.SearchHit;
 import org.springframework.data.elasticsearch.core.SearchHits;
@@ -29,13 +30,13 @@ public class StoreSearchRepositoryImpl implements StoreSearchRepositoryCustom {
         Criteria criteria = new Criteria();
 
         if (request.getName() != null && !request.getName().isEmpty()) {
-            criteria.and(new Criteria("name").contains(request.getName()));
+            criteria.and(new Criteria("name").matches(request.getName()));
         }
         if (request.getAddress() != null && !request.getAddress().isEmpty()) {
-            criteria.and(new Criteria("address").contains(request.getAddress()));
+            criteria.and(new Criteria("address").matches(request.getAddress()));
         }
         if (request.getDescription() != null && !request.getDescription().isEmpty()) {
-            criteria.and(new Criteria("description").contains(request.getDescription()));
+            criteria.and(new Criteria("description").matches(request.getDescription()));
         }
         if (request.getOpenTime() != null) {
             criteria.and(new Criteria("openTime").greaterThanEqual(request.getOpenTime()));
@@ -44,7 +45,9 @@ public class StoreSearchRepositoryImpl implements StoreSearchRepositoryCustom {
             criteria.and(new Criteria("closeTime").lessThanEqual(request.getCloseTime()));
         }
 
-        Query query = new CriteriaQuery(criteria).setPageable(pageable);
+        Query query = new CriteriaQuery(criteria)
+                .setPageable(pageable)
+                .addSort(Sort.by(Sort.Order.desc("_score"))); // 점수 내림차순 정렬 추가
 
         SearchHits<StoreDocument> searchHits = elasticsearchOperations.search(query, StoreDocument.class);
         return new PageImpl<>(

--- a/src/main/java/com/example/wait4eat/domain/store/repository/StoreSearchRepositoryImpl.java
+++ b/src/main/java/com/example/wait4eat/domain/store/repository/StoreSearchRepositoryImpl.java
@@ -1,0 +1,58 @@
+package com.example.wait4eat.domain.store.repository;
+
+import com.example.wait4eat.domain.store.dto.request.SearchStoreRequest;
+import com.example.wait4eat.domain.store.entity.StoreDocument;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHit;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.data.elasticsearch.core.query.Criteria;
+import org.springframework.data.elasticsearch.core.query.CriteriaQuery;
+import org.springframework.stereotype.Repository;
+import org.springframework.data.elasticsearch.core.query.Query;
+
+import java.util.stream.Collectors;
+
+@Repository
+public class StoreSearchRepositoryImpl implements StoreSearchRepositoryCustom {
+
+    private final ElasticsearchOperations elasticsearchOperations;
+
+    public StoreSearchRepositoryImpl(ElasticsearchOperations elasticsearchOperations) {
+        this.elasticsearchOperations = elasticsearchOperations;
+    }
+
+    @Override
+    public Page<StoreDocument> searchStores(SearchStoreRequest request, Pageable pageable) {
+        Criteria criteria = new Criteria();
+
+        if (request.getName() != null && !request.getName().isEmpty()) {
+            criteria.and(new Criteria("name").contains(request.getName()));
+        }
+        if (request.getAddress() != null && !request.getAddress().isEmpty()) {
+            criteria.and(new Criteria("address").contains(request.getAddress()));
+        }
+        if (request.getDescription() != null && !request.getDescription().isEmpty()) {
+            criteria.and(new Criteria("description").contains(request.getDescription()));
+        }
+        if (request.getOpenTime() != null) {
+            criteria.and(new Criteria("openTime").greaterThanEqual(request.getOpenTime()));
+        }
+        if (request.getCloseTime() != null) {
+            criteria.and(new Criteria("closeTime").lessThanEqual(request.getCloseTime()));
+        }
+
+        Query query = new CriteriaQuery(criteria).setPageable(pageable);
+
+        SearchHits<StoreDocument> searchHits = elasticsearchOperations.search(query, StoreDocument.class);
+        return new PageImpl<>(
+                searchHits.getSearchHits().stream()
+                        .map(SearchHit::getContent)
+                        .collect(Collectors.toList()),
+                pageable,
+                searchHits.getTotalHits()
+        );
+    }
+}

--- a/src/main/java/com/example/wait4eat/domain/store/service/StoreService.java
+++ b/src/main/java/com/example/wait4eat/domain/store/service/StoreService.java
@@ -6,13 +6,14 @@ import com.example.wait4eat.domain.store.dto.response.CreateStoreResponse;
 import com.example.wait4eat.domain.store.dto.response.GetStoreDetailResponse;
 import com.example.wait4eat.domain.store.dto.response.GetStoreListResponse;
 import com.example.wait4eat.domain.store.entity.Store;
+import com.example.wait4eat.domain.store.entity.StoreDocument;
 import com.example.wait4eat.domain.store.repository.StoreRepository;
+import com.example.wait4eat.domain.store.repository.StoreSearchRepository;
 import com.example.wait4eat.domain.user.entity.User;
 import com.example.wait4eat.domain.user.repository.UserRepository;
 import com.example.wait4eat.global.auth.dto.AuthUser;
 import com.example.wait4eat.global.exception.CustomException;
 import com.example.wait4eat.global.exception.ExceptionType;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -21,14 +22,13 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-
 @Service
 @RequiredArgsConstructor
 public class StoreService {
 
     private final StoreRepository storeRepository;
     private final UserRepository userRepository;
+    private final StoreSearchRepository storeSearchRepository;
 
     @Transactional
     public CreateStoreResponse create(AuthUser authUser, CreateStoreRequest request) {
@@ -52,6 +52,9 @@ public class StoreService {
                 .build();
 
         Store savedStore = storeRepository.save(store);
+
+        // Elasticsearch 에도 저장
+        storeSearchRepository.save(StoreDocument.from(savedStore));
 
         return CreateStoreResponse.of(savedStore, user);
     }

--- a/src/main/java/com/example/wait4eat/domain/store/service/StoreService.java
+++ b/src/main/java/com/example/wait4eat/domain/store/service/StoreService.java
@@ -14,6 +14,7 @@ import com.example.wait4eat.domain.user.repository.UserRepository;
 import com.example.wait4eat.global.auth.dto.AuthUser;
 import com.example.wait4eat.global.exception.CustomException;
 import com.example.wait4eat.global.exception.ExceptionType;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -21,6 +22,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -83,6 +87,23 @@ public class StoreService {
         // 검색 및 필터링 조건 적용
         return storeRepository.searchStores(request, pageable)
                 .map(GetStoreListResponse::from);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<GetStoreListResponse> getStoreListByEs(SearchStoreRequest request) {
+        Pageable pageable = PageRequest.of(
+                request.getPage(),
+                request.getSize(),
+                Sort.by(
+                        request.getSortDirection().equalsIgnoreCase("asc") ?
+                                Sort.Order.asc(request.getSort()) :
+                                Sort.Order.desc(request.getSort())
+                )
+        );
+
+        Page<StoreDocument> searchResult = storeSearchRepository.searchStores(request, pageable);
+
+        return searchResult.map(GetStoreListResponse::from);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/example/wait4eat/domain/store/service/StoreService.java
+++ b/src/main/java/com/example/wait4eat/domain/store/service/StoreService.java
@@ -1,6 +1,7 @@
 package com.example.wait4eat.domain.store.service;
 
 import com.example.wait4eat.domain.store.dto.request.CreateStoreRequest;
+import com.example.wait4eat.domain.store.dto.request.SearchStoreRequest;
 import com.example.wait4eat.domain.store.dto.response.CreateStoreResponse;
 import com.example.wait4eat.domain.store.dto.response.GetStoreDetailResponse;
 import com.example.wait4eat.domain.store.dto.response.GetStoreListResponse;
@@ -14,7 +15,9 @@ import com.example.wait4eat.global.exception.ExceptionType;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -54,8 +57,28 @@ public class StoreService {
     }
 
     @Transactional(readOnly = true)
-    public Page<GetStoreListResponse> getStoreList(Pageable pageable) {
-        return storeRepository.findAll(pageable)
+    public Page<GetStoreListResponse> getStoreList(SearchStoreRequest request) {
+        System.out.println("SearchStoreRequest: name=" + request.getName() +
+                ", address=" + request.getAddress() +
+                ", page=" + request.getPage() +
+                ", size=" + request.getSize());
+
+        // 정렬 설정
+        Sort sort = Sort.by(
+                request.getSortDirection().equalsIgnoreCase("asc") ?
+                        Sort.Order.asc(request.getSort()) :
+                        Sort.Order.desc(request.getSort())
+        );
+
+        // 페이징 설정
+        Pageable pageable = PageRequest.of(
+                request.getPage(),
+                request.getSize(),
+                sort
+        );
+
+        // 검색 및 필터링 조건 적용
+        return storeRepository.searchStores(request, pageable)
                 .map(GetStoreListResponse::from);
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -56,3 +56,7 @@ spring.jpa.properties.jakarta.persistence.lock.timeout=3000
 
 # Webhook
 webhook.toss.endpoint=api/payments/webhook/toss
+
+# ElasticSearch
+#spring.elasticsearch.uris=
+spring.data.elasticsearch.repositories.enabled=true

--- a/src/test/java/com/example/wait4eat/bulk/StoreBulkTest.java
+++ b/src/test/java/com/example/wait4eat/bulk/StoreBulkTest.java
@@ -1,13 +1,17 @@
 package com.example.wait4eat.bulk;
 
+import com.example.wait4eat.domain.store.dto.request.SearchStoreRequest;
+import com.example.wait4eat.domain.store.dto.response.GetStoreListResponse;
 import com.example.wait4eat.domain.store.entity.Store;
 import com.example.wait4eat.domain.store.repository.StoreBulkRepository;
+import com.example.wait4eat.domain.store.service.StoreService;
 import com.example.wait4eat.domain.user.entity.User;
 import com.example.wait4eat.domain.user.enums.UserRole;
 import com.example.wait4eat.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.time.LocalTime;
@@ -26,47 +30,123 @@ public class StoreBulkTest {
     @Autowired
     private UserRepository userRepository;
 
+    @Autowired
+    private StoreService storeService;
+
     private static final int TOTAL_STORES = 100000;
     private static final int BATCH_SIZE = 1000;
 
+//    @Test
+//    public void bulkInsertStores() {
+//        Random random = new Random();
+//
+//        // 테스트용 user 가져오기 (없으면 생성)
+//        User user = userRepository.findAll().stream().findFirst()
+//                .orElseGet(() -> {
+//                    User newUser = new User("test@example.com", "password", "tester", UserRole.ROLE_OWNER);
+//                    return userRepository.save(newUser);
+//                });
+//
+//        for (int i = 0; i < TOTAL_STORES; i += BATCH_SIZE) {
+//            List<Store> stores = new ArrayList<>();
+//
+//            for (int j = 0; j < BATCH_SIZE; j++) {
+//                String name = "가게-" + UUID.randomUUID().toString().substring(0, 8);
+//                String address = "서울시 랜덤구 " + random.nextInt(1000);
+//                LocalTime openTime = LocalTime.of(random.nextInt(24), random.nextInt(60));
+//                LocalTime closeTime = openTime.plusHours(random.nextInt(6) + 1).withMinute(random.nextInt(60));
+//                String description = "이것은 설명입니다. " + random.nextInt(1000);
+//                int depositAmount = (random.nextInt(10) + 1) * 1000;
+//                int waitingTeamCount = random.nextInt(30);
+//
+//                Store store = Store.builder()
+//                        .user(user)
+//                        .name(name)
+//                        .address(address)
+//                        .openTime(openTime)
+//                        .closeTime(closeTime)
+//                        .description(description)
+//                        .depositAmount(depositAmount)
+//                        .waitingTeamCount(waitingTeamCount)
+//                        .build();
+//
+//                stores.add(store);
+//            }
+//            storeBulkRepository.bulkInsert(stores);
+//        }
+//    }
+
     @Test
-    public void bulkInsertStores() {
-        Random random = new Random();
+    public void testJpaSearchPerformance() {
+        // 검색 요청 생성
+        SearchStoreRequest request = SearchStoreRequest.builder()
+                .name("가게") // 가게 이름으로 검색 (대용량 데이터에 포함된 패턴)
+                .address("서울") // 주소로 검색
+                .description("설명") // 설명으로 검색
+                .openTime(LocalTime.of(9, 0)) // 오픈 시간 필터
+                .closeTime(LocalTime.of(22, 0)) // 마감 시간 필터
+                .page(0) // 첫 페이지
+                .size(10) // 페이지당 10개
+                .sort("createdAt") // 생성일 기준 정렬
+                .sortDirection("desc") // 내림차순
+                .build();
 
-        // 테스트용 user 가져오기 (없으면 생성)
-        User user = userRepository.findAll().stream().findFirst()
-                .orElseGet(() -> {
-                    User newUser = new User("test@example.com", "password", "tester", UserRole.ROLE_OWNER);
-                    return userRepository.save(newUser);
-                });
+        // 검색 실행 및 응답 시간 측정
+        long startTime = System.currentTimeMillis();
+        Page<GetStoreListResponse> result = storeService.getStoreList(request);
+        long endTime = System.currentTimeMillis();
 
-        for (int i = 0; i < TOTAL_STORES; i += BATCH_SIZE) {
-            List<Store> stores = new ArrayList<>();
+        // 결과 출력
+        System.out.println("JPA 검색 시간: " + (endTime - startTime) + "ms");
+        System.out.println("검색 결과 수: " + result.getTotalElements());
+        System.out.println("페이지 수: " + result.getTotalPages());
+    }
 
-            for (int j = 0; j < BATCH_SIZE; j++) {
-                String name = "가게-" + UUID.randomUUID().toString().substring(0, 8);
-                String address = "서울시 랜덤구 " + random.nextInt(1000);
-                LocalTime openTime = LocalTime.of(random.nextInt(24), random.nextInt(60));
-                LocalTime closeTime = openTime.plusHours(random.nextInt(6) + 1).withMinute(random.nextInt(60));
-                String description = "이것은 설명입니다. " + random.nextInt(1000);
-                int depositAmount = (random.nextInt(10) + 1) * 1000;
-                int waitingTeamCount = random.nextInt(30);
+    @Test
+    public void testJpaSearchPerformanceMultipleConditions() {
+        // 다양한 검색 조건 테스트
+        SearchStoreRequest[] requests = {
+                SearchStoreRequest.builder()
+                        .name("가게")
+                        .page(0)
+                        .size(10)
+                        .sort("createdAt")
+                        .sortDirection("desc")
+                        .build(),
+                SearchStoreRequest.builder()
+                        .address("서울")
+                        .openTime(LocalTime.of(8, 0))
+                        .closeTime(LocalTime.of(23, 0))
+                        .page(0)
+                        .size(20)
+                        .sort("depositAmount")
+                        .sortDirection("asc")
+                        .build(),
+                SearchStoreRequest.builder()
+                        .description("설명")
+                        .page(1)
+                        .size(5)
+                        .sort("waitingTeamCount")
+                        .sortDirection("desc")
+                        .build()
+        };
 
-                Store store = Store.builder()
-                        .user(user)
-                        .name(name)
-                        .address(address)
-                        .openTime(openTime)
-                        .closeTime(closeTime)
-                        .description(description)
-                        .depositAmount(depositAmount)
-                        .waitingTeamCount(waitingTeamCount)
-                        .build();
+        for (int i = 0; i < requests.length; i++) {
+            SearchStoreRequest request = requests[i];
+            long startTime = System.currentTimeMillis();
+            Page<GetStoreListResponse> result = storeService.getStoreList(request);
+            long endTime = System.currentTimeMillis();
 
-                stores.add(store);
-            }
-
-            storeBulkRepository.bulkInsert(stores);
+            System.out.println("테스트 " + (i + 1) + ":");
+            System.out.println("조건: name=" + request.getName() +
+                    ", address=" + request.getAddress() +
+                    ", description=" + request.getDescription() +
+                    ", openTime=" + request.getOpenTime() +
+                    ", closeTime=" + request.getCloseTime());
+            System.out.println("JPA 검색 시간: " + (endTime - startTime) + "ms");
+            System.out.println("검색 결과 수: " + result.getTotalElements());
+            System.out.println("페이지 수: " + result.getTotalPages());
+            System.out.println("--------------------");
         }
     }
 }

--- a/src/test/java/com/example/wait4eat/bulk/StoreBulkTest.java
+++ b/src/test/java/com/example/wait4eat/bulk/StoreBulkTest.java
@@ -1,222 +1,290 @@
-package com.example.wait4eat.bulk;
-
-import com.example.wait4eat.domain.store.dto.request.SearchStoreRequest;
-import com.example.wait4eat.domain.store.dto.response.GetStoreListResponse;
-import com.example.wait4eat.domain.store.entity.Store;
-import com.example.wait4eat.domain.store.entity.StoreDocument;
-import com.example.wait4eat.domain.store.repository.StoreBulkRepository;
-import com.example.wait4eat.domain.store.repository.StoreRepository;
-import com.example.wait4eat.domain.store.repository.StoreSearchRepository;
-import com.example.wait4eat.domain.store.service.StoreService;
-import com.example.wait4eat.domain.user.entity.User;
-import com.example.wait4eat.domain.user.enums.UserRole;
-import com.example.wait4eat.domain.user.repository.UserRepository;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.test.context.ActiveProfiles;
-
-import java.time.LocalTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Random;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
-@SpringBootTest
-@ActiveProfiles("test")
-public class StoreBulkTest {
-
-    @Autowired
-    private StoreBulkRepository storeBulkRepository;
-
-    @Autowired
-    private UserRepository userRepository;
-
-    @Autowired
-    private StoreService storeService;
-
-    @Autowired
-    private StoreRepository storeRepository;
-
-    @Autowired
-    private StoreSearchRepository storeSearchRepository;
-
-    private static final int TOTAL_STORES = 100000;
-    private static final int BATCH_SIZE = 1000;
-
+//package com.example.wait4eat.bulk;
+//
+//import com.example.wait4eat.domain.store.dto.request.SearchStoreRequest;
+//import com.example.wait4eat.domain.store.dto.response.GetStoreListResponse;
+//import com.example.wait4eat.domain.store.entity.Store;
+//import com.example.wait4eat.domain.store.entity.StoreDocument;
+//import com.example.wait4eat.domain.store.repository.StoreBulkRepository;
+//import com.example.wait4eat.domain.store.repository.StoreRepository;
+//import com.example.wait4eat.domain.store.repository.StoreSearchRepository;
+//import com.example.wait4eat.domain.store.service.StoreService;
+//import com.example.wait4eat.domain.user.entity.User;
+//import com.example.wait4eat.domain.user.enums.UserRole;
+//import com.example.wait4eat.domain.user.repository.UserRepository;
+//import org.junit.jupiter.api.Test;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.boot.test.context.SpringBootTest;
+//import org.springframework.data.domain.Page;
+//import org.springframework.data.domain.PageRequest;
+//import org.springframework.data.domain.Pageable;
+//import org.springframework.test.context.ActiveProfiles;
+//
+//import java.time.LocalTime;
+//import java.util.ArrayList;
+//import java.util.List;
+//import java.util.Random;
+//import java.util.UUID;
+//import java.util.stream.Collectors;
+//
+//@SpringBootTest
+//@ActiveProfiles("test")
+//public class StoreBulkTest {
+//
+//    @Autowired
+//    private StoreBulkRepository storeBulkRepository;
+//
+//    @Autowired
+//    private UserRepository userRepository;
+//
+//    @Autowired
+//    private StoreService storeService;
+//
+//    @Autowired
+//    private StoreRepository storeRepository;
+//
+//    @Autowired
+//    private StoreSearchRepository storeSearchRepository;
+//
+//    private static final int TOTAL_STORES = 100000;
+//    private static final int BATCH_SIZE = 1000;
+//
+////    @Test
+////    public void bulkInsertStores() {
+////        Random random = new Random();
+////
+////        // 테스트용 user 가져오기 (없으면 생성)
+////        User user = userRepository.findAll().stream().findFirst()
+////                .orElseGet(() -> {
+////                    User newUser = new User("test@example.com", "password", "tester", UserRole.ROLE_OWNER);
+////                    return userRepository.save(newUser);
+////                });
+////
+////        for (int i = 0; i < TOTAL_STORES; i += BATCH_SIZE) {
+////            List<Store> stores = new ArrayList<>();
+////
+////            for (int j = 0; j < BATCH_SIZE; j++) {
+////                String name = "가게-" + UUID.randomUUID().toString().substring(0, 8);
+////                String address = "서울시 랜덤구 " + random.nextInt(1000);
+////                LocalTime openTime = LocalTime.of(random.nextInt(24), random.nextInt(60));
+////                LocalTime closeTime = openTime.plusHours(random.nextInt(6) + 1).withMinute(random.nextInt(60));
+////                String description = "이것은 설명입니다. " + random.nextInt(1000);
+////                int depositAmount = (random.nextInt(10) + 1) * 1000;
+////                int waitingTeamCount = random.nextInt(30);
+////
+////                Store store = Store.builder()
+////                        .user(user)
+////                        .name(name)
+////                        .address(address)
+////                        .openTime(openTime)
+////                        .closeTime(closeTime)
+////                        .description(description)
+////                        .depositAmount(depositAmount)
+////                        .waitingTeamCount(waitingTeamCount)
+////                        .build();
+////
+////                stores.add(store);
+////            }
+////            storeBulkRepository.bulkInsert(stores);
+////        }
+////    }
+//
 //    @Test
-//    public void bulkInsertStores() {
-//        Random random = new Random();
+//    public void testBulkSyncToElasticsearch() {
+//        // 동기화 시작 시간 기록
+//        long startTime = System.currentTimeMillis();
 //
-//        // 테스트용 user 가져오기 (없으면 생성)
-//        User user = userRepository.findAll().stream().findFirst()
-//                .orElseGet(() -> {
-//                    User newUser = new User("test@example.com", "password", "tester", UserRole.ROLE_OWNER);
-//                    return userRepository.save(newUser);
-//                });
+//        int page = 0;
+//        int size = BATCH_SIZE;
+//        Page<Store> storePage;
 //
-//        for (int i = 0; i < TOTAL_STORES; i += BATCH_SIZE) {
-//            List<Store> stores = new ArrayList<>();
+//        do {
+//            Pageable pageable = PageRequest.of(page, size);
+//            storePage = storeRepository.findAll(pageable);
 //
-//            for (int j = 0; j < BATCH_SIZE; j++) {
-//                String name = "가게-" + UUID.randomUUID().toString().substring(0, 8);
-//                String address = "서울시 랜덤구 " + random.nextInt(1000);
-//                LocalTime openTime = LocalTime.of(random.nextInt(24), random.nextInt(60));
-//                LocalTime closeTime = openTime.plusHours(random.nextInt(6) + 1).withMinute(random.nextInt(60));
-//                String description = "이것은 설명입니다. " + random.nextInt(1000);
-//                int depositAmount = (random.nextInt(10) + 1) * 1000;
-//                int waitingTeamCount = random.nextInt(30);
+//            System.out.println("Processing page " + page + ", total elements: " + storePage.getTotalElements() +
+//                    ", total pages: " + storePage.getTotalPages());
 //
-//                Store store = Store.builder()
-//                        .user(user)
-//                        .name(name)
-//                        .address(address)
-//                        .openTime(openTime)
-//                        .closeTime(closeTime)
-//                        .description(description)
-//                        .depositAmount(depositAmount)
-//                        .waitingTeamCount(waitingTeamCount)
-//                        .build();
-//
-//                stores.add(store);
+//            try {
+//                List<StoreDocument> documents = storePage.getContent().stream()
+//                        .map(StoreDocument::from)
+//                        .collect(Collectors.toList());
+//                storeSearchRepository.saveAll(documents);
+//                System.out.println("Synced " + documents.size() + " stores to Elasticsearch, page " + page);
+//            } catch (Exception e) {
+//                System.err.println("Error syncing stores to Elasticsearch, page " + page + ": " + e.getMessage());
 //            }
-//            storeBulkRepository.bulkInsert(stores);
+//
+//            page++;
+//        } while (storePage.hasNext());
+//
+//        // 동기화 종료 시간 기록
+//        long endTime = System.currentTimeMillis();
+//        System.out.println("ES 동기화 시간: " + (endTime - startTime) + "ms");
+//    }
+//
+//    @Test
+//    public void testCompareJpaAndEsPerformance() {
+//        // 테스트할 검색 조건들
+//        SearchStoreRequest[] requests = {
+//                // 시나리오 1: 텍스트 검색 (name)
+//                SearchStoreRequest.builder()
+//                        .name("가게")
+//                        .page(0)
+//                        .size(10)
+//                        .sort("createdAt")
+//                        .sortDirection("desc")
+//                        .build(),
+//                // 시나리오 2: 범위 검색 (depositAmount)
+//                SearchStoreRequest.builder()
+//                        .name("가게")
+//                        .page(0)
+//                        .size(10)
+//                        .sort("depositAmount")
+//                        .sortDirection("asc")
+//                        .build(),
+//                // 시나리오 3: 복합 조건 (name + address + openTime)
+//                SearchStoreRequest.builder()
+//                        .name("가게")
+//                        .address("서울")
+//                        .openTime(LocalTime.of(9, 0))
+//                        .page(0)
+//                        .size(10)
+//                        .sort("createdAt")
+//                        .sortDirection("desc")
+//                        .build()
+//        };
+//
+//        for (int i = 0; i < requests.length; i++) {
+//            SearchStoreRequest request = requests[i];
+//            System.out.println("테스트 시나리오 " + (i + 1) + ":");
+//
+//            // JPA 검색
+//            long jpaStartTime = System.currentTimeMillis();
+//            Page<GetStoreListResponse> jpaResult = storeService.getStoreList(request);
+//            long jpaEndTime = System.currentTimeMillis();
+//
+//            // ES 검색
+//            long esStartTime = System.currentTimeMillis();
+//            Page<GetStoreListResponse> esResult = storeService.getStoreListByEs(request);
+//            long esEndTime = System.currentTimeMillis();
+//
+//            // 조건 출력
+//            System.out.println("조건: name=" + request.getName() +
+//                    ", address=" + request.getAddress() +
+//                    ", openTime=" + request.getOpenTime() +
+//                    ", sort=" + request.getSort() +
+//                    ", sortDirection=" + request.getSortDirection());
+//
+//            // JPA 결과
+//            System.out.println("JPA 검색 시간: " + (jpaEndTime - jpaStartTime) + "ms");
+//            System.out.println("JPA 검색 결과 수: " + jpaResult.getTotalElements());
+//            System.out.println("JPA 페이지 수: " + jpaResult.getTotalPages());
+//
+//            // ES 결과
+//            System.out.println("ES 검색 시간: " + (esEndTime - esStartTime) + "ms");
+//            System.out.println("ES 검색 결과 수: " + esResult.getTotalElements());
+//            System.out.println("ES 페이지 수: " + esResult.getTotalPages());
+//
+//            System.out.println("--------------------");
 //        }
 //    }
-
-    @Test
-    public void testBulkSyncToElasticsearch() {
-        // 동기화 시작 시간 기록
-        long startTime = System.currentTimeMillis();
-
-        int page = 0;
-        int size = BATCH_SIZE;
-        Page<Store> storePage;
-
-        do {
-            Pageable pageable = PageRequest.of(page, size);
-            storePage = storeRepository.findAll(pageable);
-
-            System.out.println("Processing page " + page + ", total elements: " + storePage.getTotalElements() +
-                    ", total pages: " + storePage.getTotalPages());
-
-            try {
-                List<StoreDocument> documents = storePage.getContent().stream()
-                        .map(StoreDocument::from)
-                        .collect(Collectors.toList());
-                storeSearchRepository.saveAll(documents);
-                System.out.println("Synced " + documents.size() + " stores to Elasticsearch, page " + page);
-            } catch (Exception e) {
-                System.err.println("Error syncing stores to Elasticsearch, page " + page + ": " + e.getMessage());
-            }
-
-            page++;
-        } while (storePage.hasNext());
-
-        // 동기화 종료 시간 기록
-        long endTime = System.currentTimeMillis();
-        System.out.println("ES 동기화 시간: " + (endTime - startTime) + "ms");
-    }
-
-
-    @Test
-    public void testJpaSearchPerformance() {
-        // 검색 요청 생성
-        SearchStoreRequest request = SearchStoreRequest.builder()
-                .name("가게") // 가게 이름으로 검색 (대용량 데이터에 포함된 패턴)
-                .address("서울") // 주소로 검색
-                .description("설명") // 설명으로 검색
-                .openTime(LocalTime.of(9, 0)) // 오픈 시간 필터
-                .closeTime(LocalTime.of(22, 0)) // 마감 시간 필터
-                .page(0) // 첫 페이지
-                .size(10) // 페이지당 10개
-                .sort("createdAt") // 생성일 기준 정렬
-                .sortDirection("desc") // 내림차순
-                .build();
-
-        // 검색 실행 및 응답 시간 측정
-        long startTime = System.currentTimeMillis();
-        Page<GetStoreListResponse> result = storeService.getStoreList(request);
-        long endTime = System.currentTimeMillis();
-
-        // 결과 출력
-        System.out.println("JPA 검색 시간: " + (endTime - startTime) + "ms");
-        System.out.println("검색 결과 수: " + result.getTotalElements());
-        System.out.println("페이지 수: " + result.getTotalPages());
-    }
-
-    @Test
-    public void testJpaSearchPerformanceMultipleConditions() {
-        // 다양한 검색 조건 테스트
-        SearchStoreRequest[] requests = {
-                SearchStoreRequest.builder()
-                        .name("가게")
-                        .page(0)
-                        .size(10)
-                        .sort("createdAt")
-                        .sortDirection("desc")
-                        .build(),
-                SearchStoreRequest.builder()
-                        .address("서울")
-                        .openTime(LocalTime.of(8, 0))
-                        .closeTime(LocalTime.of(23, 0))
-                        .page(0)
-                        .size(20)
-                        .sort("depositAmount")
-                        .sortDirection("asc")
-                        .build(),
-                SearchStoreRequest.builder()
-                        .description("설명")
-                        .page(1)
-                        .size(5)
-                        .sort("waitingTeamCount")
-                        .sortDirection("desc")
-                        .build()
-        };
-
-        for (int i = 0; i < requests.length; i++) {
-            SearchStoreRequest request = requests[i];
-            long startTime = System.currentTimeMillis();
-            Page<GetStoreListResponse> result = storeService.getStoreList(request);
-            long endTime = System.currentTimeMillis();
-
-            System.out.println("테스트 " + (i + 1) + ":");
-            System.out.println("조건: name=" + request.getName() +
-                    ", address=" + request.getAddress() +
-                    ", description=" + request.getDescription() +
-                    ", openTime=" + request.getOpenTime() +
-                    ", closeTime=" + request.getCloseTime());
-            System.out.println("JPA 검색 시간: " + (endTime - startTime) + "ms");
-            System.out.println("검색 결과 수: " + result.getTotalElements());
-            System.out.println("페이지 수: " + result.getTotalPages());
-            System.out.println("--------------------");
-        }
-    }
-
-    @Test
-    public void testEsSearchPerformance() {
-        SearchStoreRequest request = SearchStoreRequest.builder()
-                .name("가게")
-                .address("서울")
-                .description("설명")
-                .openTime(LocalTime.of(9, 0))
-                .closeTime(LocalTime.of(22, 0))
-                .page(0)
-                .size(10)
-                .sort("createdAt")
-                .sortDirection("desc")
-                .build();
-
-        long startTime = System.currentTimeMillis();
-        Page<GetStoreListResponse> result = storeService.getStoreListByEs(request);
-        long endTime = System.currentTimeMillis();
-
-        System.out.println("ES 검색 시간: " + (endTime - startTime) + "ms");
-        System.out.println("검색 결과 수: " + result.getTotalElements());
-        System.out.println("페이지 수: " + result.getTotalPages());
-    }
-}
+//
+//
+//
+//    @Test
+//    public void testJpaSearchPerformance() {
+//        // 검색 요청 생성
+//        SearchStoreRequest request = SearchStoreRequest.builder()
+//                .name("가게") // 가게 이름으로 검색 (대용량 데이터에 포함된 패턴)
+//                .address("서울") // 주소로 검색
+//                .description("설명") // 설명으로 검색
+//                .openTime(LocalTime.of(9, 0)) // 오픈 시간 필터
+//                .closeTime(LocalTime.of(22, 0)) // 마감 시간 필터
+//                .page(0) // 첫 페이지
+//                .size(10) // 페이지당 10개
+//                .sort("createdAt") // 생성일 기준 정렬
+//                .sortDirection("desc") // 내림차순
+//                .build();
+//
+//        // 검색 실행 및 응답 시간 측정
+//        long startTime = System.currentTimeMillis();
+//        Page<GetStoreListResponse> result = storeService.getStoreList(request);
+//        long endTime = System.currentTimeMillis();
+//
+//        // 결과 출력
+//        System.out.println("JPA 검색 시간: " + (endTime - startTime) + "ms");
+//        System.out.println("검색 결과 수: " + result.getTotalElements());
+//        System.out.println("페이지 수: " + result.getTotalPages());
+//    }
+//
+//    @Test
+//    public void testJpaSearchPerformanceMultipleConditions() {
+//        // 다양한 검색 조건 테스트
+//        SearchStoreRequest[] requests = {
+//                SearchStoreRequest.builder()
+//                        .name("가게")
+//                        .page(0)
+//                        .size(10)
+//                        .sort("createdAt")
+//                        .sortDirection("desc")
+//                        .build(),
+//                SearchStoreRequest.builder()
+//                        .address("서울")
+//                        .openTime(LocalTime.of(8, 0))
+//                        .closeTime(LocalTime.of(23, 0))
+//                        .page(0)
+//                        .size(20)
+//                        .sort("depositAmount")
+//                        .sortDirection("asc")
+//                        .build(),
+//                SearchStoreRequest.builder()
+//                        .description("설명")
+//                        .page(1)
+//                        .size(5)
+//                        .sort("waitingTeamCount")
+//                        .sortDirection("desc")
+//                        .build()
+//        };
+//
+//        for (int i = 0; i < requests.length; i++) {
+//            SearchStoreRequest request = requests[i];
+//            long startTime = System.currentTimeMillis();
+//            Page<GetStoreListResponse> result = storeService.getStoreList(request);
+//            long endTime = System.currentTimeMillis();
+//
+//            System.out.println("테스트 " + (i + 1) + ":");
+//            System.out.println("조건: name=" + request.getName() +
+//                    ", address=" + request.getAddress() +
+//                    ", description=" + request.getDescription() +
+//                    ", openTime=" + request.getOpenTime() +
+//                    ", closeTime=" + request.getCloseTime());
+//            System.out.println("JPA 검색 시간: " + (endTime - startTime) + "ms");
+//            System.out.println("검색 결과 수: " + result.getTotalElements());
+//            System.out.println("페이지 수: " + result.getTotalPages());
+//            System.out.println("--------------------");
+//        }
+//    }
+//
+//    @Test
+//    public void testEsSearchPerformance() {
+//        SearchStoreRequest request = SearchStoreRequest.builder()
+//                .name("가게")
+//                .address("서울")
+//                .description("설명")
+//                .openTime(LocalTime.of(9, 0))
+//                .closeTime(LocalTime.of(22, 0))
+//                .page(0)
+//                .size(10)
+//                .sort("createdAt")
+//                .sortDirection("desc")
+//                .build();
+//
+//        long startTime = System.currentTimeMillis();
+//        Page<GetStoreListResponse> result = storeService.getStoreListByEs(request);
+//        long endTime = System.currentTimeMillis();
+//
+//        System.out.println("ES 검색 시간: " + (endTime - startTime) + "ms");
+//        System.out.println("검색 결과 수: " + result.getTotalElements());
+//        System.out.println("페이지 수: " + result.getTotalPages());
+//    }
+//}

--- a/src/test/java/com/example/wait4eat/bulk/StoreBulkTest.java
+++ b/src/test/java/com/example/wait4eat/bulk/StoreBulkTest.java
@@ -1,0 +1,72 @@
+package com.example.wait4eat.bulk;
+
+import com.example.wait4eat.domain.store.entity.Store;
+import com.example.wait4eat.domain.store.repository.StoreBulkRepository;
+import com.example.wait4eat.domain.user.entity.User;
+import com.example.wait4eat.domain.user.enums.UserRole;
+import com.example.wait4eat.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public class StoreBulkTest {
+
+    @Autowired
+    private StoreBulkRepository storeBulkRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private static final int TOTAL_STORES = 100000;
+    private static final int BATCH_SIZE = 1000;
+
+    @Test
+    public void bulkInsertStores() {
+        Random random = new Random();
+
+        // 테스트용 user 가져오기 (없으면 생성)
+        User user = userRepository.findAll().stream().findFirst()
+                .orElseGet(() -> {
+                    User newUser = new User("test@example.com", "password", "tester", UserRole.ROLE_OWNER);
+                    return userRepository.save(newUser);
+                });
+
+        for (int i = 0; i < TOTAL_STORES; i += BATCH_SIZE) {
+            List<Store> stores = new ArrayList<>();
+
+            for (int j = 0; j < BATCH_SIZE; j++) {
+                String name = "가게-" + UUID.randomUUID().toString().substring(0, 8);
+                String address = "서울시 랜덤구 " + random.nextInt(1000);
+                LocalTime openTime = LocalTime.of(random.nextInt(24), random.nextInt(60));
+                LocalTime closeTime = openTime.plusHours(random.nextInt(6) + 1).withMinute(random.nextInt(60));
+                String description = "이것은 설명입니다. " + random.nextInt(1000);
+                int depositAmount = (random.nextInt(10) + 1) * 1000;
+                int waitingTeamCount = random.nextInt(30);
+
+                Store store = Store.builder()
+                        .user(user)
+                        .name(name)
+                        .address(address)
+                        .openTime(openTime)
+                        .closeTime(closeTime)
+                        .description(description)
+                        .depositAmount(depositAmount)
+                        .waitingTeamCount(waitingTeamCount)
+                        .build();
+
+                stores.add(store);
+            }
+
+            storeBulkRepository.bulkInsert(stores);
+        }
+    }
+}


### PR DESCRIPTION
## 🧩 연관된 이슈

> #62, #67, #78

## ✅ 작업 내용

> 단순 가게 리스트 조회 기능에 '정렬/페이징/검색' 기능 추가
> ES 도입하여 '정렬/페이징/검색' 기능 구현
 
## 📷 테스트

> Postman으로 JPA 가게 검색 요청을 보내 정상적으로 조건에 맞는 가게 리스트가 응답됨을 확인
> Postman으로 ES 가게 검색 요청을 보내 정상적으로 조건에 맞는 가게 리스트가 응답됨을 확인

this closes #62, #67, #78
