### PR TITLE
[#115] 웨이팅 호출 시 알림 메시지 수정

### DIFF
--- a/src/main/java/com/example/wait4eat/domain/waiting/event/handler/WaitingCalledEventHandler.java
+++ b/src/main/java/com/example/wait4eat/domain/waiting/event/handler/WaitingCalledEventHandler.java
@@ -34,9 +34,9 @@ public class WaitingCalledEventHandler {
 
         NotificationMessagePublishRequest notificationMessagePublishRequest = new NotificationMessagePublishRequest(
                 MessageType.WAITING_CALLED,
-                NotificationType.COUPON_EVENT_LAUNCHED.getMessage(),
+                NotificationType.WAITING_CALLED.getMessage(),
                 List.of(user),
-                NotificationType.COUPON_EVENT_LAUNCHED
+                NotificationType.WAITING_CALLED
         );
 
         List<OutboxMessage> outboxes = messageStagingService.stage(notificationMessagePublishRequest);


### PR DESCRIPTION
## 🧩 연관된 이슈

#115 

## ✅ 작업 내용

기존 `NotificationType.COUPON_EVENT_LAUNCHED`로 잘못 설정되어 있던 부분을 `NotificationType.WAITING_CALLED`로 수정
 
## 📷 테스트

포스트맨 테스트 완료

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
