### PR TITLE
Outbox 재시도 대상 추가 및 PaymentMessageProcessor에 메시지 처리 확인 로직 추가

### DIFF
--- a/src/main/java/com/example/wait4eat/global/message/outbox/repository/OutboxMessageRepository.java
+++ b/src/main/java/com/example/wait4eat/global/message/outbox/repository/OutboxMessageRepository.java
@@ -11,14 +11,14 @@ import java.util.List;
 public interface OutboxMessageRepository extends JpaRepository<OutboxMessage, String> {
 
     @Query(value = """
-                SELECT * FROM outbox_messages
-                WHERE status = 'FAILED'
-                AND retry_count < :maxRetry
-                ORDER BY created_at ASC
-                LIMIT :limit
-            """,
-            nativeQuery = true)
-    List<OutboxMessage> findFailedOutboxByRetryCountLessThanOrderByCreatedAtDesc(int maxRetry, int limit);
+    SELECT * FROM outbox_messages
+    WHERE status IN ('FAILED', 'PENDING')
+    AND retry_count < :maxRetry
+    ORDER BY created_at ASC
+    LIMIT :limit
+    """, nativeQuery = true)
+    List<OutboxMessage> findRetryableOutboxMessages(int maxRetry, int limit);
+
 
     @Modifying
     @Query("UPDATE OutboxMessage o SET o.status = 'SENT', o.sentAt = :now WHERE o.id IN :ids")

--- a/src/main/java/com/example/wait4eat/global/message/service/PaymentMessageProcessor.java
+++ b/src/main/java/com/example/wait4eat/global/message/service/PaymentMessageProcessor.java
@@ -1,20 +1,25 @@
 package com.example.wait4eat.global.message.service;
 
 import com.example.wait4eat.domain.payment.service.PaymentService;
+import com.example.wait4eat.global.message.dedup.MessageDeduplicationHandler;
 import com.example.wait4eat.global.message.outbox.enums.AggregateType;
 import com.example.wait4eat.global.message.payload.EventMessagePayload;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
 public class PaymentMessageProcessor {
 
     private final PaymentService paymentService;
+    private final MessageDeduplicationHandler messageDeduplicationHandler;
 
+    @Transactional
     public void handlePaymentMessage(EventMessagePayload payload) {
         if (AggregateType.PAYMENT_REFUND.name().equals(payload.getAggregateType())) {
             paymentService.refundPayment(payload.getTargetId(), payload.getMessage());
+            messageDeduplicationHandler.markAsProcessed(payload.getMessageKey());
         }
     }
 }

--- a/src/main/java/com/example/wait4eat/scheduler/OutboxRetryScheduler.java
+++ b/src/main/java/com/example/wait4eat/scheduler/OutboxRetryScheduler.java
@@ -30,7 +30,7 @@ public class OutboxRetryScheduler { // TODO : 여러 인스턴스에서 동시�
     @Scheduled(fixedRate = 10000)
     public void retry() {
         List<OutboxMessage> messages = outboxMessageRepository
-                .findFailedOutboxByRetryCountLessThanOrderByCreatedAtDesc(
+                .findRetryableOutboxMessages(
                         MAX_RETRY_COUNT,
                         BATCH_SIZE
                 );


### PR DESCRIPTION
## 🧩 연관된 이슈

없음

## ✅ 작업 내용

- 기존 실패 마킹된 outbox만 재처리하던 로직에서 `PENDING` 상태의 outbox를 포함하도록 메서드 변경
- PaymentMessageProcessor 메서드에 트랜잭션을 걸고 메시지 처리 마킹하는 로직을 추가
 
## 📷 테스트

> 기능이 정상적으로 돌아가는 지 어떤 부분을 테스트했는 지 작성해주세요

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
