### PR TITLE
[#118, #119] Outbox 발행 로직 비동기 전환

### DIFF
--- a/src/main/java/com/example/wait4eat/Wait4eatApplication.java
+++ b/src/main/java/com/example/wait4eat/Wait4eatApplication.java
@@ -6,8 +6,6 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@EnableScheduling
-@EnableAsync
 @EnableJpaAuditing
 @SpringBootApplication
 public class Wait4eatApplication {

--- a/src/main/java/com/example/wait4eat/domain/store/repository/StoreSearchRepository.java
+++ b/src/main/java/com/example/wait4eat/domain/store/repository/StoreSearchRepository.java
@@ -2,12 +2,14 @@ package com.example.wait4eat.domain.store.repository;
 
 import com.example.wait4eat.domain.store.dto.request.SearchStoreRequest;
 import com.example.wait4eat.domain.store.entity.StoreDocument;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
+@ConditionalOnProperty(name = "feature.search.enabled", havingValue = "true")
 public interface StoreSearchRepository extends ElasticsearchRepository<StoreDocument, String>, StoreSearchRepositoryCustom {
 
     Page<StoreDocument> searchStores(SearchStoreRequest request, Pageable pageable);

--- a/src/main/java/com/example/wait4eat/global/config/AsyncConfig.java
+++ b/src/main/java/com/example/wait4eat/global/config/AsyncConfig.java
@@ -1,0 +1,10 @@
+package com.example.wait4eat.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+}

--- a/src/main/java/com/example/wait4eat/global/config/ExecutorConfig.java
+++ b/src/main/java/com/example/wait4eat/global/config/ExecutorConfig.java
@@ -1,0 +1,34 @@
+package com.example.wait4eat.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Configuration
+public class ExecutorConfig {
+
+    @Bean(name = "outboxExecutor")
+    public ExecutorService outboxExecutor() {
+        AtomicInteger threadNumber = new AtomicInteger(1);
+
+        ThreadFactory threadFactory = runnable -> {
+            Thread thread = new Thread(runnable);
+            thread.setName("outbox-executor-" + threadNumber.getAndIncrement());
+            return thread;
+        };
+
+        return new ThreadPoolExecutor(
+          10,
+          20,
+          60L, TimeUnit.SECONDS,
+          new LinkedBlockingQueue<>(1000),
+                threadFactory,
+                new ThreadPoolExecutor.CallerRunsPolicy()
+        );
+    }
+}
+
+
+

--- a/src/main/java/com/example/wait4eat/global/message/dedup/CompositeMessageDeduplicationHandler.java
+++ b/src/main/java/com/example/wait4eat/global/message/dedup/CompositeMessageDeduplicationHandler.java
@@ -33,6 +33,6 @@ public class CompositeMessageDeduplicationHandler implements MessageDeduplicatio
             throw new RuntimeException(e); // 재시도 유도
         }
 
-        log.info("messageKey 처리 마킹 완료: {}", messageKey);
+        // log.info("messageKey 처리 마킹 완료: {}", messageKey);
     }
 }

--- a/src/main/java/com/example/wait4eat/global/message/outbox/entity/OutboxMessage.java
+++ b/src/main/java/com/example/wait4eat/global/message/outbox/entity/OutboxMessage.java
@@ -32,7 +32,7 @@ public class OutboxMessage {
     @Column
     private String aggregateId;
 
-    @Column(nullable = false)
+    @Column(columnDefinition = "TEXT", nullable = false)
     private String payload;
 
     @Column(nullable = false)

--- a/src/main/java/com/example/wait4eat/global/message/outbox/repository/OutboxMessageRepository.java
+++ b/src/main/java/com/example/wait4eat/global/message/outbox/repository/OutboxMessageRepository.java
@@ -19,7 +19,6 @@ public interface OutboxMessageRepository extends JpaRepository<OutboxMessage, St
     """, nativeQuery = true)
     List<OutboxMessage> findRetryableOutboxMessages(int maxRetry, int limit);
 
-
     @Modifying
     @Query("UPDATE OutboxMessage o SET o.status = 'SENT', o.sentAt = :now WHERE o.id IN :ids")
     int markAllAsSent(List<String> ids, LocalDateTime now);
@@ -28,5 +27,8 @@ public interface OutboxMessageRepository extends JpaRepository<OutboxMessage, St
     @Query("UPDATE OutboxMessage o SET o.status = 'FAILED' WHERE o.id IN :ids")
     int markAllAsFailed(List<String> ids);
 
-   // boolean existsByIdAndIsProcessed(String messageKey, boolean isProcessed);
+    @Modifying
+    @Query("update OutboxMessage o set o.status = 'FAILED' where o.status = 'PENDING' and o.createdAt < :threshold")
+    int markPendingAsFailedBefore(LocalDateTime threshold);
+
 }

--- a/src/main/java/com/example/wait4eat/global/message/outbox/repository/OutboxMessageRepository.java
+++ b/src/main/java/com/example/wait4eat/global/message/outbox/repository/OutboxMessageRepository.java
@@ -12,7 +12,7 @@ public interface OutboxMessageRepository extends JpaRepository<OutboxMessage, St
 
     @Query(value = """
     SELECT * FROM outbox_messages
-    WHERE status IN ('FAILED', 'PENDING')
+    WHERE status IN ('FAILED')
     AND retry_count < :maxRetry
     ORDER BY created_at ASC
     LIMIT :limit

--- a/src/main/java/com/example/wait4eat/global/message/outbox/service/OutboxPublisher.java
+++ b/src/main/java/com/example/wait4eat/global/message/outbox/service/OutboxPublisher.java
@@ -1,0 +1,55 @@
+package com.example.wait4eat.global.message.outbox.service;
+
+import com.example.wait4eat.global.message.outbox.entity.OutboxMessage;
+import com.example.wait4eat.global.message.outbox.repository.OutboxMessageRepository;
+import com.example.wait4eat.global.message.publisher.MessagePublisher;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OutboxPublisher {
+
+    private final MessagePublisher publisher;
+    private final OutboxMessageRepository outboxMessageRepository;
+    private final AggregateQueueMapper aggregateQueueMapper;
+
+    @Async("outboxExecutor")
+    @Transactional
+    public void publishBatch(List<OutboxMessage> messages) {
+        String threadName = Thread.currentThread().getName();
+        log.info("[OUTBOX-PUBLISHER] 시작 - thread={}", threadName);
+
+        List<String> successIds = new ArrayList<>();
+        List<String> failedIds = new ArrayList<>();
+
+        for (OutboxMessage message : messages) {
+            try {
+                String queueName = aggregateQueueMapper.getQueueName(message.getAggregateType());
+                publisher.publish(queueName, message.getPayload());
+                successIds.add(message.getId());
+            } catch (Exception e) {
+                log.warn("Failed to publish outbox : id={}, reason={}", message.getId(), e.getMessage());
+                failedIds.add(message.getId());
+            }
+        }
+
+        if (!successIds.isEmpty()) {
+            outboxMessageRepository.markAllAsSent(successIds, LocalDateTime.now());
+            log.info("Published {} messages successfully on thread {}", successIds.size(), threadName);
+        }
+        if (!failedIds.isEmpty()) {
+            outboxMessageRepository.markAllAsFailed(failedIds);
+            log.warn("Failed to publish {} messages on thread {}", failedIds.size(), threadName);
+        }
+    }
+}

--- a/src/main/java/com/example/wait4eat/global/util/IdGenerator.java
+++ b/src/main/java/com/example/wait4eat/global/util/IdGenerator.java
@@ -11,7 +11,7 @@ public class IdGenerator {
     }
 
     public static String generateNotificationId() {
-        return UUID.randomUUID().toString().substring(0,8);
+        return UUID.randomUUID().toString();
     }
 
 }

--- a/src/main/java/com/example/wait4eat/scheduler/OutboxExpirationScheduler.java
+++ b/src/main/java/com/example/wait4eat/scheduler/OutboxExpirationScheduler.java
@@ -1,0 +1,30 @@
+package com.example.wait4eat.scheduler;
+
+import com.example.wait4eat.global.message.outbox.repository.OutboxMessageRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OutboxExpirationScheduler {
+
+    private final OutboxMessageRepository outboxMessageRepository;
+
+    /**
+     * 즉시 발행에 실패한 메시지를 FAILED로 자동 보정
+     */
+    @Scheduled(fixedDelay = 1, timeUnit = TimeUnit.MINUTES)
+    @Transactional
+    public void markOldPendingMessagesAsFailed() {
+        int updatedCount = outboxMessageRepository.markPendingAsFailedBefore(LocalDateTime.now().minusMinutes(1));
+        log.info("[OutboxExpirationScheduler] 1분 이상 PENDING 상태인 메시지 {}건을 FAILED로 변경", updatedCount);
+
+    }
+}


### PR DESCRIPTION
## 🧩 연관된 이슈

closes #118 , closes #119 

## ✅ 작업 내용

1. Oubox 발행 로직을 비동기로 전환
- Outbox 메시지 발행 시 `@Async` 기반 비동기 구조로 리팩토링하여 응답 속도를 개선했습니다.
- 메시지 발행 책임은 기존 OutboxProcessor에서 OutboxPublisher로 변경되었습니다. 
- OutboxProcessor 는 메시지를 Batch 단위로 비동기 분산 처리만 책임집니다.

2. ElasticSearch 조건부 등록 설정
- `feature.search.enable` 설정에 따라 `ElasticsearchRepository` 빈을 등록하도록 하여 개발환경에서 구동 중인 엘라스틱서치 서버를 등록하지 않아도 정상적으로 프로젝트를 실행할 수 있도록 하였습니다.

3. OutboxMessage의 id 생성 방식 변경
- `substring()` 을 이용하여 UUID의 일부만 사용하던 방식에서 UUID 전체를 사용하도록 변경하여 중복 가능성을 제거했습니다.
 
## 📷 테스트

**1.  스레드풀 정상 동작 확인**
<img width="900" alt="Screenshot 2025-05-16 at 19 50 06" src="https://github.com/user-attachments/assets/b38dd200-50eb-4a64-98ca-ca02e128bc80" />
<img width="900" alt="Screenshot 2025-05-16 at 19 50 22" src="https://github.com/user-attachments/assets/97c7bb08-e370-4683-8e1d-cb90a3c9e22d" />

**2. 포스트맨으로 응답 속도 향상 확인** 

> 찜한 유저가 20000명인 가게에서 쿠폰 이벤트 발행

- 비동기 적용 전 응답 속도 7m 31s
<img width="990" alt="Screenshot 2025-05-16 at 20 55 24" src="https://github.com/user-attachments/assets/46d59186-0770-4e13-b78a-f0d866491780" />

- 적용 후 응답 속도 4.4s
<img width="893" alt="Screenshot 2025-05-16 at 19 50 34" src="https://github.com/user-attachments/assets/96cbf66e-5fa4-4e92-9eb9-65dab36bfcd3" />

약 451초에서 약 5초로 개선, 총 99%에 달하는 처리 속도 향상

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
